### PR TITLE
fix: make the IPC open handler actually open

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -980,7 +980,10 @@ Item {
     IpcHandler {
         target: "expose"
         function open(): string {
-            root.toggle();
+            // Must not be root.toggle(): that makes "open" a duplicate of
+            // "toggle", so calling open on an already-open overview closes it.
+            // Mirrors close(), which correctly calls dismiss().
+            root.open("{}");
             return "ok";
         }
         function close(): string {


### PR DESCRIPTION
## The problem

The `open` IPC verb calls `root.toggle()`:

```qml
function open(): string {
    root.toggle();
    return "ok";
}
```

That makes `open` identical to `toggle`, so calling it on an already-open overview **closes** it.

`close()` is correct — it calls `dismiss()`.

## Why it matters

It breaks any binding that maps open and close to separate actions. I hit this with a touchpad gesture where three fingers up opens and three fingers down closes:

```lua
hl.exec_cmd("omarchy-shell expose open")   -- swipe up
hl.exec_cmd("omarchy-shell expose close")  -- swipe down
```

Swiping up a second time dismissed the overview instead of leaving it open. The README documents `open` and `close` as distinct from `toggle`, so the behaviour is surprising.

## The fix

Point it at `root.open()`, which already exists at line 108 and is what `toggle()` itself calls in the not-open branch. Mirrors `close()` calling `dismiss()`.

Verified on Omarchy 4.0.0 / Hyprland 0.56.2: calling `open` twice now leaves the overview open, and `close` still dismisses it.

Note that overlay plugins need a full `omarchy restart shell` to pick this up — `rescanPlugins` reloads the file but does not re-instantiate the component, which made it look like the fix had not applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)