### PR TITLE
fix: keep a workspace swipe made while the overview is open

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
+import Quickshell.Hyprland
 import qs.Commons
 
 Item {
@@ -119,6 +120,7 @@ Item {
     }
 
     function open(payload) {
+        root.swipedWorkspace = "";
         dismissTimer.stop();
         dismissTimer.notifyShell = false;
         root.closeSettings();
@@ -400,6 +402,7 @@ Item {
             String(top.title || ""),
             root.moveCursorToWindow ? "true" : "false"
         ]);
+        root.swipedWorkspace = "";
         root.dismiss();
     }
 
@@ -1122,6 +1125,42 @@ Item {
         event.accepted = true;
     }
 
+    // A three-finger workspace swipe still reaches the compositor while the
+    // overview is open, and it does switch — but Hyprland restores focus to the
+    // last focused toplevel when the layer surface unmaps, which drags the
+    // workspace back to where it started. The swipe looks like it worked and
+    // then silently undoes itself. Remember where it left off and re-apply it
+    // once the surface is gone, the way activate-window waits out the same
+    // unmap before taking focus.
+    property string swipedWorkspace: ""
+
+    Connections {
+        target: Hyprland
+        function onRawEvent(event) {
+            if (!root.opened || !event)
+                return;
+            if (String(event.name) !== "workspace")
+                return;
+            var name = String(event.data || "").trim();
+            // Only plain workspace names, since this is handed to a shell.
+            if (/^[A-Za-z0-9_:-]{1,64}$/.test(name))
+                root.swipedWorkspace = name;
+        }
+    }
+
+    Timer {
+        id: swipedWorkspaceRestore
+        interval: 60
+        onTriggered: {
+            var target = root.swipedWorkspace;
+            root.swipedWorkspace = "";
+            if (!target)
+                return;
+            Quickshell.execDetached(["hyprctl", "eval",
+                "hl.dispatch(hl.dsp.focus({ workspace = '" + target + "' }))"]);
+        }
+    }
+
     Connections {
         target: ToplevelManager.toplevels
         function onValuesChanged() {
@@ -1158,6 +1197,8 @@ Item {
         onTriggered: {
             root.surfaceMounted = false;
             backgroundBlurSession.running = false;
+            if (root.swipedWorkspace)
+                swipedWorkspaceRestore.restart();
             if (notifyShell && root.shell && typeof root.shell.hide === "function")
                 root.shell.hide(root.pluginId);
             notifyShell = false;


### PR DESCRIPTION
The overview does not block three-finger workspace swipes, so the workspace really does switch underneath it. But Hyprland restores focus to the last focused toplevel when the layer surface unmaps, which drags the workspace back to where it started — the swipe appears to work and then silently undoes itself the moment the overview closes.

To reproduce: open the overview on workspace 1, swipe to workspace 2 (it switches, visibly), then close the overview. You are back on workspace 1.

This is the same unmap that `activate-window` already works around with its `sleep 0.2` before taking final compositor focus, which is what pointed at the cause.

The fix remembers the workspace a swipe landed on while the overview was open and re-applies it once the surface is gone. Activating a window clears the remembered workspace, so a click still wins over an earlier swipe.

Verified on Hyprland 0.56.2 / Omarchy 4.0.0:

- open on ws1, swipe to ws5, close → lands on ws5
- open on ws1, click a window on ws2, close → lands on ws2 with that window focused
- no swipe, open and close → unchanged

An earlier attempt that dismissed the overview on any workspace change was rejected: it broke click-to-activate, sending you back to the workspace you opened from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)