### PR TITLE
feat: add configurable overview animations

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -592,24 +592,38 @@ Item {
         return true;
     }
 
-    function handleSettingsTab(event) {
-        if (!root.settingsOpen
-                || (event.key !== Qt.Key_Tab && event.key !== Qt.Key_Backtab))
+    // Tab/Shift+Tab wrap through every focusable item. Up/Down (and Left/Right
+    // inside the confirmation dialog) step without wrapping, so arrow keys never
+    // jump from the last control back to the sidebar.
+    function handleSettingsNavigation(event) {
+        if (!root.settingsOpen)
             return false;
-        var forward = event.key !== Qt.Key_Backtab
-            && !(event.modifiers & Qt.ShiftModifier);
+        var isTab = event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab;
+        var isStep = event.key === Qt.Key_Up || event.key === Qt.Key_Down
+            || (root.footerHideConfirmationOpen && (event.key === Qt.Key_Left || event.key === Qt.Key_Right));
+        if (!isTab && !isStep)
+            return false;
+        var forward = isTab
+            ? event.key !== Qt.Key_Backtab && !(event.modifiers & Qt.ShiftModifier)
+            : event.key === Qt.Key_Down || event.key === Qt.Key_Right;
         for (var index = 0; index < surfaceInstances.instances.length; index++) {
             var surface = surfaceInstances.instances[index];
             if (!surface || !surface.acceptsKeyboard)
                 continue;
             if (root.footerHideConfirmationOpen)
-                surface.moveFooterConfirmationFocus(forward);
+                surface.moveFooterConfirmationFocus(forward, isTab);
             else
-                surface.moveSettingsFocus(forward);
+                surface.moveSettingsFocus(forward, isTab);
             event.accepted = true;
             return true;
         }
         return false;
+    }
+
+    function handleSettingsTab(event) {
+        if (event.key !== Qt.Key_Tab && event.key !== Qt.Key_Backtab)
+            return false;
+        return root.handleSettingsNavigation(event);
     }
 
     function setFilter(value) {
@@ -1638,11 +1652,11 @@ Item {
         }
 
         Keys.onPressed: function (event) {
-            if (root.handleSettingsTab(event))
+            if (root.handleSettingsNavigation(event))
                 return;
-            if (event.key === Qt.Key_Left || event.key === Qt.Key_Down)
+            if (event.key === Qt.Key_Left)
                 settingSlider.commitKeyboardValue(settingSlider.value - settingSlider.stepSize);
-            else if (event.key === Qt.Key_Right || event.key === Qt.Key_Up)
+            else if (event.key === Qt.Key_Right)
                 settingSlider.commitKeyboardValue(settingSlider.value + settingSlider.stepSize);
             else if (event.key === Qt.Key_Home)
                 settingSlider.commitKeyboardValue(settingSlider.from);
@@ -1730,26 +1744,31 @@ Item {
         spacing: Style.spacing.lg
         activeFocusOnTab: true
 
-        function chooseOffset(offset) {
-            if (!settingChoices.options.length)
+        // Arrows stop at either end; Space/Enter cycle through every option.
+        function chooseOffset(offset, wrap) {
+            var count = settingChoices.options.length;
+            if (!count)
                 return;
             var current = 0;
-            for (var index = 0; index < settingChoices.options.length; index++)
+            for (var index = 0; index < count; index++)
                 if (String(settingChoices.options[index].value) === settingChoices.value)
                     current = index;
-            var next = (current + offset + settingChoices.options.length) % settingChoices.options.length;
-            settingChoices.chosen(String(settingChoices.options[next].value));
+            var next = wrap
+                ? (current + offset + count) % count
+                : Math.max(0, Math.min(count - 1, current + offset));
+            if (next !== current)
+                settingChoices.chosen(String(settingChoices.options[next].value));
         }
 
         Keys.onPressed: function (event) {
-            if (root.handleSettingsTab(event))
+            if (root.handleSettingsNavigation(event))
                 return;
-            if (event.key === Qt.Key_Left || event.key === Qt.Key_Up)
-                settingChoices.chooseOffset(-1);
-            else if (event.key === Qt.Key_Right || event.key === Qt.Key_Down)
-                settingChoices.chooseOffset(1);
+            if (event.key === Qt.Key_Left)
+                settingChoices.chooseOffset(-1, false);
+            else if (event.key === Qt.Key_Right)
+                settingChoices.chooseOffset(1, false);
             else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
-                settingChoices.chooseOffset(0);
+                settingChoices.chooseOffset(1, true);
             else {
                 event.accepted = false;
                 return;
@@ -1819,21 +1838,23 @@ Item {
         spacing: 0
         activeFocusOnTab: true
 
-        function chooseOffset(offset) {
-            var current = displayModeChoices.value === "per-monitor" ? 1 : 0;
-            var next = (current + offset + displayModeChoices.options.length) % displayModeChoices.options.length;
-            displayModeChoices.chosen(String(displayModeChoices.options[next].value));
+        function choose(index) {
+            var next = Math.max(0, Math.min(displayModeChoices.options.length - 1, index));
+            var value = String(displayModeChoices.options[next].value);
+            if (value !== displayModeChoices.value)
+                displayModeChoices.chosen(value);
         }
 
         Keys.onPressed: function (event) {
-            if (root.handleSettingsTab(event))
+            if (root.handleSettingsNavigation(event))
                 return;
-            if (event.key === Qt.Key_Left || event.key === Qt.Key_Up)
-                displayModeChoices.chooseOffset(-1);
-            else if (event.key === Qt.Key_Right || event.key === Qt.Key_Down)
-                displayModeChoices.chooseOffset(1);
+            var current = displayModeChoices.value === "per-monitor" ? 1 : 0;
+            if (event.key === Qt.Key_Left)
+                displayModeChoices.choose(current - 1);
+            else if (event.key === Qt.Key_Right)
+                displayModeChoices.choose(current + 1);
             else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
-                displayModeChoices.chooseOffset(0);
+                displayModeChoices.choose(1 - current);
             else {
                 event.accepted = false;
                 return;
@@ -1915,23 +1936,35 @@ Item {
         implicitHeight: Style.space(horizontal ? 52 : 48)
         activeFocusOnTab: selected
 
+        signal entered()
+
         function choose(nextIndex) {
-            categoryButton.chosen(Math.max(0, Math.min(3, nextIndex)));
+            var next = Math.max(0, Math.min(3, nextIndex));
+            if (next !== categoryButton.categoryIndex)
+                categoryButton.chosen(next);
         }
 
+        // The sidebar is a list: arrows along its axis pick a section, the
+        // arrow pointing at the content (or Enter/Space) moves focus into it.
         Keys.onPressed: function (event) {
             if (root.handleSettingsTab(event))
                 return;
-            if (event.key === Qt.Key_Up || event.key === Qt.Key_Left)
-                categoryButton.choose((categoryButton.categoryIndex + 3) % 4);
-            else if (event.key === Qt.Key_Down || event.key === Qt.Key_Right)
-                categoryButton.choose((categoryButton.categoryIndex + 1) % 4);
+            var previousKey = categoryButton.horizontal ? Qt.Key_Left : Qt.Key_Up;
+            var nextKey = categoryButton.horizontal ? Qt.Key_Right : Qt.Key_Down;
+            var enterKey = categoryButton.horizontal ? Qt.Key_Down : Qt.Key_Right;
+            if (event.key === previousKey)
+                categoryButton.choose(categoryButton.categoryIndex - 1);
+            else if (event.key === nextKey)
+                categoryButton.choose(categoryButton.categoryIndex + 1);
             else if (event.key === Qt.Key_Home)
                 categoryButton.choose(0);
             else if (event.key === Qt.Key_End)
                 categoryButton.choose(3);
-            else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
-                categoryButton.choose(categoryButton.categoryIndex);
+            else if (event.key === enterKey
+                    || event.key === Qt.Key_Space
+                    || event.key === Qt.Key_Return
+                    || event.key === Qt.Key_Enter)
+                categoryButton.entered();
             else {
                 event.accepted = false;
                 return;
@@ -2020,13 +2053,21 @@ Item {
         activeFocusOnTab: true
 
         Keys.onPressed: function (event) {
-            if (root.handleSettingsTab(event))
+            if (root.handleSettingsNavigation(event))
                 return;
-            if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
+            var next;
+            if (event.key === Qt.Key_Left)
+                next = false;
+            else if (event.key === Qt.Key_Right)
+                next = true;
+            else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
+                next = !settingToggle.checked;
+            else {
                 event.accepted = false;
                 return;
             }
-            settingToggle.toggled(!settingToggle.checked);
+            if (next !== settingToggle.checked)
+                settingToggle.toggled(next);
             event.accepted = true;
         }
 
@@ -2093,7 +2134,7 @@ Item {
         opacity: enabled ? 1 : 0.38
 
         Keys.onPressed: function (event) {
-            if (root.handleSettingsTab(event))
+            if (root.handleSettingsNavigation(event))
                 return;
             if (!enabled || (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter)) {
                 event.accepted = false;
@@ -2242,12 +2283,12 @@ Item {
                     ]);
                 return overviewWindow.availableFocusItems([
                     categoryButton,
+                    motionAnimateButton,
                     animationStyleChoices,
                     animationSpeedSlider,
                     animationInSlider,
                     animationOutSlider,
-                    animationSameSpeedToggle,
-                    motionAnimateButton
+                    animationSameSpeedToggle
                 ]);
             }
 
@@ -2259,7 +2300,7 @@ Item {
                 ]);
             }
 
-            function moveFocus(items, forward, forwardFallbackIndex) {
+            function moveFocus(items, forward, forwardFallbackIndex, wrap) {
                 if (!items.length)
                     return;
                 var focusedIndex = -1;
@@ -2269,18 +2310,30 @@ Item {
                         break;
                     }
                 }
-                var nextIndex = focusedIndex < 0
-                    ? (forward ? Math.min(forwardFallbackIndex, items.length - 1) : items.length - 1)
-                    : (focusedIndex + (forward ? 1 : items.length - 1)) % items.length;
+                var nextIndex;
+                if (focusedIndex < 0)
+                    nextIndex = forward ? Math.min(forwardFallbackIndex, items.length - 1) : items.length - 1;
+                else if (wrap)
+                    nextIndex = (focusedIndex + (forward ? 1 : items.length - 1)) % items.length;
+                else
+                    nextIndex = focusedIndex + (forward ? 1 : -1);
+                if (nextIndex < 0 || nextIndex >= items.length)
+                    return;
                 root.focusSettingsItem(items[nextIndex]);
             }
 
-            function moveSettingsFocus(forward) {
-                overviewWindow.moveFocus(overviewWindow.settingsFocusItems(), forward, 1);
+            function moveSettingsFocus(forward, wrap) {
+                overviewWindow.moveFocus(overviewWindow.settingsFocusItems(), forward, 1, wrap);
             }
 
-            function moveFooterConfirmationFocus(forward) {
-                overviewWindow.moveFocus(overviewWindow.footerConfirmationFocusItems(), forward, 0);
+            function focusFirstSettingsControl() {
+                var items = overviewWindow.settingsFocusItems();
+                if (items.length > 1)
+                    root.focusSettingsItem(items[1]);
+            }
+
+            function moveFooterConfirmationFocus(forward, wrap) {
+                overviewWindow.moveFocus(overviewWindow.footerConfirmationFocusItems(), forward, 0, wrap);
             }
 
             onAcceptsKeyboardChanged: {
@@ -2329,7 +2382,7 @@ Item {
                         event.accepted = true;
                         return;
                     }
-                    if (root.handleSettingsTab(event))
+                    if (root.handleSettingsNavigation(event))
                         return;
                     root.handleKey(event, overviewArea.windowLayout);
                 }
@@ -2961,7 +3014,7 @@ Item {
                                     Item { Layout.fillWidth: true }
 
                                     Text {
-                                        text: "Esc close"
+                                        text: "1-4 section   ↑↓ move   ←→ adjust   Esc close"
                                         textFormat: Text.PlainText
                                         color: Color.menu.text
                                         opacity: 0.5
@@ -3018,6 +3071,7 @@ Item {
                                                     if (nextButton)
                                                         nextButton.forceActiveFocus();
                                                 }
+                                                onEntered: overviewWindow.focusFirstSettingsControl()
                                             }
                                         }
                                     }
@@ -3724,7 +3778,7 @@ Item {
                                     activeFocusOnTab: true
 
                                     Keys.onPressed: function (event) {
-                                        if (root.handleSettingsTab(event))
+                                        if (root.handleSettingsNavigation(event))
                                             return;
                                         if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
                                             event.accepted = false;

--- a/Overview.qml
+++ b/Overview.qml
@@ -1939,9 +1939,7 @@ Item {
         signal entered()
 
         function choose(nextIndex) {
-            var next = Math.max(0, Math.min(3, nextIndex));
-            if (next !== categoryButton.categoryIndex)
-                categoryButton.chosen(next);
+            categoryButton.chosen(Math.max(0, Math.min(3, nextIndex)));
         }
 
         // The sidebar is a list: arrows along its axis pick a section, the

--- a/Overview.qml
+++ b/Overview.qml
@@ -2053,19 +2053,11 @@ Item {
         Keys.onPressed: function (event) {
             if (root.handleSettingsNavigation(event))
                 return;
-            var next;
-            if (event.key === Qt.Key_Left)
-                next = false;
-            else if (event.key === Qt.Key_Right)
-                next = true;
-            else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
-                next = !settingToggle.checked;
-            else {
+            if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
                 event.accepted = false;
                 return;
             }
-            if (next !== settingToggle.checked)
-                settingToggle.toggled(next);
+            settingToggle.toggled(!settingToggle.checked);
             event.accepted = true;
         }
 

--- a/Overview.qml
+++ b/Overview.qml
@@ -114,6 +114,7 @@ Item {
     property bool previewNavigationSlowMotion: false
     property bool openingAfterClientRefresh: false
     property bool settingsOpen: false
+    property int settingsCategoryIndex: 0
     property bool footerHideConfirmationOpen: false
     property bool footerHideAcknowledged: false
     property string animationDurationPreviewStyle: ""
@@ -461,7 +462,12 @@ Item {
         root.clearAnimationTimingPreview();
         root.backgroundBlurPreview = -1;
         root.backgroundDimPreview = -1;
+        root.settingsCategoryIndex = 0;
         root.settingsOpen = true;
+        Qt.callLater(function () {
+            if (root.settingsOpen)
+                root.focusSettingsCategory();
+        });
     }
 
     function closeSettings() {
@@ -567,6 +573,43 @@ Item {
                 return;
             }
         }
+    }
+
+    function focusSettingsCategory() {
+        for (var i = 0; i < surfaceInstances.instances.length; i++) {
+            var surface = surfaceInstances.instances[i];
+            if (surface && surface.acceptsKeyboard) {
+                surface.focusSettingsCategory();
+                return;
+            }
+        }
+    }
+
+    function focusSettingsItem(item) {
+        if (!item || !item.visible || !item.enabled)
+            return false;
+        item.forceActiveFocus();
+        return true;
+    }
+
+    function handleSettingsTab(event) {
+        if (!root.settingsOpen
+                || (event.key !== Qt.Key_Tab && event.key !== Qt.Key_Backtab))
+            return false;
+        var forward = event.key !== Qt.Key_Backtab
+            && !(event.modifiers & Qt.ShiftModifier);
+        for (var index = 0; index < surfaceInstances.instances.length; index++) {
+            var surface = surfaceInstances.instances[index];
+            if (!surface || !surface.acceptsKeyboard)
+                continue;
+            if (root.footerHideConfirmationOpen)
+                surface.moveFooterConfirmationFocus(forward);
+            else
+                surface.moveSettingsFocus(forward);
+            event.accepted = true;
+            return true;
+        }
+        return false;
     }
 
     function setFilter(value) {
@@ -1595,6 +1638,8 @@ Item {
         }
 
         Keys.onPressed: function (event) {
+            if (root.handleSettingsTab(event))
+                return;
             if (event.key === Qt.Key_Left || event.key === Qt.Key_Down)
                 settingSlider.commitKeyboardValue(settingSlider.value - settingSlider.stepSize);
             else if (event.key === Qt.Key_Right || event.key === Qt.Key_Up)
@@ -1603,8 +1648,10 @@ Item {
                 settingSlider.commitKeyboardValue(settingSlider.from);
             else if (event.key === Qt.Key_End)
                 settingSlider.commitKeyboardValue(settingSlider.to);
-            else
+            else {
+                event.accepted = false;
                 return;
+            }
             event.accepted = true;
         }
 
@@ -1667,9 +1714,10 @@ Item {
                 horizontalAlignment: Text.AlignRight
                 text: Math.round(settingSlider.value) + settingSlider.suffix
                 textFormat: Text.PlainText
-                color: Color.menu.text
+                color: settingSlider.activeFocus ? Color.accent : Color.menu.text
                 font.family: Style.font.menuFamily
                 font.pixelSize: Style.font.caption
+                font.bold: settingSlider.activeFocus
             }
         }
     }
@@ -1694,14 +1742,18 @@ Item {
         }
 
         Keys.onPressed: function (event) {
+            if (root.handleSettingsTab(event))
+                return;
             if (event.key === Qt.Key_Left || event.key === Qt.Key_Up)
                 settingChoices.chooseOffset(-1);
             else if (event.key === Qt.Key_Right || event.key === Qt.Key_Down)
                 settingChoices.chooseOffset(1);
             else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
                 settingChoices.chooseOffset(0);
-            else
+            else {
+                event.accepted = false;
                 return;
+            }
             event.accepted = true;
         }
 
@@ -1720,7 +1772,7 @@ Item {
                     anchors.centerIn: parent
                     text: String(choice.modelData.label)
                     textFormat: Text.PlainText
-                    color: Color.menu.text
+                    color: choice.selected && settingChoices.activeFocus ? Color.accent : Color.menu.text
                     opacity: choice.selected ? 1 : 0.45
                     font.family: Style.font.menuFamily
                     font.pixelSize: Style.font.caption
@@ -1774,14 +1826,18 @@ Item {
         }
 
         Keys.onPressed: function (event) {
+            if (root.handleSettingsTab(event))
+                return;
             if (event.key === Qt.Key_Left || event.key === Qt.Key_Up)
                 displayModeChoices.chooseOffset(-1);
             else if (event.key === Qt.Key_Right || event.key === Qt.Key_Down)
                 displayModeChoices.chooseOffset(1);
             else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
                 displayModeChoices.chooseOffset(0);
-            else
+            else {
+                event.accepted = false;
                 return;
+            }
             event.accepted = true;
         }
 
@@ -1847,6 +1903,114 @@ Item {
         }
     }
 
+    component SettingsCategoryButton: Item {
+        id: categoryButton
+        property int categoryIndex: 0
+        property string label: ""
+        property bool selected: false
+        property bool horizontal: false
+        property bool hovered: false
+        signal chosen(int nextIndex)
+        implicitWidth: Style.space(horizontal ? 140 : 200)
+        implicitHeight: Style.space(horizontal ? 52 : 48)
+        activeFocusOnTab: selected
+
+        function choose(nextIndex) {
+            categoryButton.chosen(Math.max(0, Math.min(3, nextIndex)));
+        }
+
+        Keys.onPressed: function (event) {
+            if (root.handleSettingsTab(event))
+                return;
+            if (event.key === Qt.Key_Up || event.key === Qt.Key_Left)
+                categoryButton.choose((categoryButton.categoryIndex + 3) % 4);
+            else if (event.key === Qt.Key_Down || event.key === Qt.Key_Right)
+                categoryButton.choose((categoryButton.categoryIndex + 1) % 4);
+            else if (event.key === Qt.Key_Home)
+                categoryButton.choose(0);
+            else if (event.key === Qt.Key_End)
+                categoryButton.choose(3);
+            else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
+                categoryButton.choose(categoryButton.categoryIndex);
+            else {
+                event.accepted = false;
+                return;
+            }
+            event.accepted = true;
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: Color.accent
+            opacity: categoryButton.selected ? 0.07 : (categoryButton.hovered ? 0.035 : 0)
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.bottom: parent.bottom
+            width: categoryButton.horizontal ? parent.width : Math.max(2, Style.focusBorderWidth)
+            height: categoryButton.horizontal ? Math.max(2, Style.focusBorderWidth) : parent.height
+            visible: categoryButton.selected
+            color: Color.accent
+        }
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: Style.space(categoryButton.horizontal ? 8 : 18)
+            anchors.rightMargin: Style.space(categoryButton.horizontal ? 8 : 18)
+            spacing: Style.spacing.md
+
+            Text {
+                Layout.preferredWidth: Style.space(18)
+                text: String(categoryButton.categoryIndex + 1)
+                textFormat: Text.PlainText
+                horizontalAlignment: Text.AlignHCenter
+                color: categoryButton.selected ? Color.accent : Color.menu.text
+                opacity: categoryButton.selected || categoryButton.hovered ? 1 : 0.45
+                font.family: Style.font.menuFamily
+                font.pixelSize: Style.font.caption
+                font.bold: categoryButton.selected
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: categoryButton.label
+                textFormat: Text.PlainText
+                horizontalAlignment: Text.AlignLeft
+                color: Color.menu.text
+                opacity: categoryButton.selected || categoryButton.hovered ? 1 : 0.55
+                font.family: Style.font.menuFamily
+                font.pixelSize: Style.font.bodySmall
+                font.bold: categoryButton.selected
+                elide: Text.ElideRight
+            }
+
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: Style.space(2)
+            color: "transparent"
+            border.color: categoryButton.activeFocus ? Color.accent : "transparent"
+            border.width: categoryButton.activeFocus ? Math.max(2, Style.focusBorderWidth) : 0
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onEntered: categoryButton.hovered = true
+            onExited: categoryButton.hovered = false
+            onPressed: categoryButton.forceActiveFocus()
+            onClicked: categoryButton.choose(categoryButton.categoryIndex)
+        }
+    }
+
+    component SettingsDivider: Rectangle {
+        implicitHeight: Math.max(1, Style.normalBorderWidth)
+        color: Color.menu.border
+    }
+
     component SettingToggle: Item {
         id: settingToggle
         property bool checked: false
@@ -1856,8 +2020,12 @@ Item {
         activeFocusOnTab: true
 
         Keys.onPressed: function (event) {
-            if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter)
+            if (root.handleSettingsTab(event))
                 return;
+            if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
+                event.accepted = false;
+                return;
+            }
             settingToggle.toggled(!settingToggle.checked);
             event.accepted = true;
         }
@@ -1893,6 +2061,15 @@ Item {
             }
         }
 
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: -Style.space(4)
+            visible: settingToggle.activeFocus
+            color: "transparent"
+            border.color: Color.accent
+            border.width: Math.max(2, Style.focusBorderWidth)
+        }
+
         MouseArea {
             anchors.fill: parent
             cursorShape: Qt.PointingHandCursor
@@ -1916,8 +2093,12 @@ Item {
         opacity: enabled ? 1 : 0.38
 
         Keys.onPressed: function (event) {
-            if (!enabled || (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter))
+            if (root.handleSettingsTab(event))
                 return;
+            if (!enabled || (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter)) {
+                event.accepted = false;
+                return;
+            }
             dialogButton.clicked();
             event.accepted = true;
         }
@@ -2020,6 +2201,93 @@ Item {
             readonly property string screenWorkspaceLabel: root.activeWorkspaceLabelForScreen(String(modelData.name || ""))
             readonly property string screenScopeLabel: root.workspaceScopeLabelForScreen(String(modelData.name || ""))
 
+            function focusSettingsCategory() {
+                var categoryButton = settingsCategoryRepeater.itemAt(root.settingsCategoryIndex);
+                if (categoryButton)
+                    categoryButton.forceActiveFocus();
+            }
+
+            function availableFocusItems(candidates) {
+                var items = [];
+                for (var index = 0; index < candidates.length; index++) {
+                    var candidate = candidates[index];
+                    if (candidate && candidate.visible && candidate.enabled)
+                        items.push(candidate);
+                }
+                return items;
+            }
+
+            function settingsFocusItems() {
+                var categoryButton = settingsCategoryRepeater.itemAt(root.settingsCategoryIndex);
+                if (root.settingsCategoryIndex === 0)
+                    return overviewWindow.availableFocusItems([
+                        categoryButton,
+                        backgroundBlurSlider,
+                        backgroundDimSlider,
+                        bottomTextToggle
+                    ]);
+                if (root.settingsCategoryIndex === 1)
+                    return overviewWindow.availableFocusItems([
+                        categoryButton,
+                        hotCornerToggle,
+                        hotCornerPositionChoices
+                    ]);
+                if (root.settingsCategoryIndex === 2)
+                    return overviewWindow.availableFocusItems([
+                        categoryButton,
+                        previewPlacementChoices,
+                        windowFooterChoices,
+                        movePointerToggle,
+                        displayModeChoicesControl
+                    ]);
+                return overviewWindow.availableFocusItems([
+                    categoryButton,
+                    animationStyleChoices,
+                    animationSpeedSlider,
+                    animationInSlider,
+                    animationOutSlider,
+                    animationSameSpeedToggle,
+                    motionAnimateButton
+                ]);
+            }
+
+            function footerConfirmationFocusItems() {
+                return overviewWindow.availableFocusItems([
+                    footerHideAcknowledgement,
+                    footerHideCancelButton,
+                    footerHideConfirmButton
+                ]);
+            }
+
+            function moveFocus(items, forward, forwardFallbackIndex) {
+                if (!items.length)
+                    return;
+                var focusedIndex = -1;
+                for (var index = 0; index < items.length; index++) {
+                    if (items[index].activeFocus) {
+                        focusedIndex = index;
+                        break;
+                    }
+                }
+                var nextIndex = focusedIndex < 0
+                    ? (forward ? Math.min(forwardFallbackIndex, items.length - 1) : items.length - 1)
+                    : (focusedIndex + (forward ? 1 : items.length - 1)) % items.length;
+                root.focusSettingsItem(items[nextIndex]);
+            }
+
+            function moveSettingsFocus(forward) {
+                overviewWindow.moveFocus(overviewWindow.settingsFocusItems(), forward, 1);
+            }
+
+            function moveFooterConfirmationFocus(forward) {
+                overviewWindow.moveFocus(overviewWindow.footerConfirmationFocusItems(), forward, 0);
+            }
+
+            onAcceptsKeyboardChanged: {
+                if (acceptsKeyboard && root.settingsOpen)
+                    Qt.callLater(overviewWindow.focusSettingsCategory);
+            }
+
             Region {
                 id: backgroundBlurRegion
                 item: overviewWindow.contentItem
@@ -2052,6 +2320,17 @@ Item {
                 }
                 Keys.priority: Keys.BeforeItem
                 Keys.onPressed: function (event) {
+                    if (root.settingsOpen
+                            && !root.footerHideConfirmationOpen
+                            && event.key >= Qt.Key_1
+                            && event.key <= Qt.Key_4) {
+                        root.settingsCategoryIndex = event.key - Qt.Key_1;
+                        Qt.callLater(overviewWindow.focusSettingsCategory);
+                        event.accepted = true;
+                        return;
+                    }
+                    if (root.handleSettingsTab(event))
+                        return;
                     root.handleKey(event, overviewArea.windowLayout);
                 }
 
@@ -2631,10 +2910,7 @@ Item {
                     z: 200
                     onVisibleChanged: {
                         if (visible && overviewWindow.acceptsKeyboard)
-                            Qt.callLater(function () {
-                                if (settingsLayer.visible)
-                                    backgroundBlurSlider.forceActiveFocus();
-                            });
+                            Qt.callLater(overviewWindow.focusSettingsCategory);
                     }
 
                     MouseArea {
@@ -2647,11 +2923,12 @@ Item {
                         readonly property bool narrow: width < Style.space(760)
                         anchors.centerIn: parent
                         width: Math.min(Style.space(920), parent.width - Style.space(80))
-                        height: Math.min(Style.space(narrow ? 1000 : 640), parent.height - Style.space(80))
+                        height: Math.min(Style.space(narrow ? 720 : 640), parent.height - Style.space(80))
                         radius: Style.cornerRadius
                         color: Color.menu.background
                         border.color: Color.menu.border
                         border.width: Math.max(1, Style.normalBorderWidth)
+                        enabled: !root.footerHideConfirmationOpen
 
                         MouseArea {
                             anchors.fill: parent
@@ -2660,458 +2937,695 @@ Item {
 
                         ColumnLayout {
                             anchors.fill: parent
-                            anchors.margins: Style.space(28)
-                            spacing: Style.spacing.xl
+                            spacing: 0
 
-                            RowLayout {
+                            Item {
                                 Layout.fillWidth: true
+                                Layout.preferredHeight: Style.space(66)
 
-                                Text {
-                                    text: "Exposé settings"
-                                    textFormat: Text.PlainText
-                                    color: Color.menu.text
-                                    font.family: Style.font.menuFamily
-                                    font.pixelSize: Style.font.heading
-                                    font.bold: true
-                                }
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Style.space(24)
+                                    anchors.rightMargin: Style.space(24)
+                                    spacing: Style.spacing.lg
 
-                                Item { Layout.fillWidth: true }
+                                    Text {
+                                        text: "Exposé settings"
+                                        textFormat: Text.PlainText
+                                        color: Color.menu.text
+                                        font.family: Style.font.menuFamily
+                                        font.pixelSize: Style.font.heading
+                                        font.bold: true
+                                    }
 
-                                Text {
-                                    text: "Click outside or Esc to close"
-                                    textFormat: Text.PlainText
-                                    visible: !settingsDialog.narrow
-                                    color: Color.menu.text
-                                    opacity: 0.5
-                                    font.family: Style.font.menuFamily
-                                    font.pixelSize: Style.font.caption
+                                    Item { Layout.fillWidth: true }
+
+                                    Text {
+                                        text: "Esc close"
+                                        textFormat: Text.PlainText
+                                        color: Color.menu.text
+                                        opacity: 0.5
+                                        font.family: Style.font.menuFamily
+                                        font.pixelSize: Style.font.caption
+                                    }
                                 }
                             }
 
-                            Rectangle {
-                                Layout.fillWidth: true
-                                Layout.preferredHeight: Math.max(1, Style.normalBorderWidth)
-                                color: Color.menu.border
-                            }
+                            SettingsDivider { Layout.fillWidth: true }
 
                             GridLayout {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
                                 columns: settingsDialog.narrow ? 1 : 2
-                                columnSpacing: settingsDialog.narrow ? 0 : Style.space(48)
-                                rowSpacing: settingsDialog.narrow ? Style.space(28) : 0
+                                columnSpacing: 0
+                                rowSpacing: 0
 
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    Layout.fillHeight: true
-                                    spacing: Style.spacing.lg
+                                Item {
+                                    Layout.fillWidth: settingsDialog.narrow
+                                    Layout.fillHeight: !settingsDialog.narrow
+                                    Layout.preferredWidth: settingsDialog.narrow ? 0 : Style.space(218)
+                                    Layout.preferredHeight: settingsDialog.narrow ? Style.space(54) : 0
 
-                                    Text {
-                                        text: "Background"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.55
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
-                                    }
+                                    GridLayout {
+                                        anchors.top: parent.top
+                                        anchors.left: parent.left
+                                        anchors.right: parent.right
+                                        columns: settingsDialog.narrow ? 4 : 1
+                                        columnSpacing: 0
+                                        rowSpacing: 0
 
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Blur"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        SettingSlider {
-                                            id: backgroundBlurSlider
-                                            Layout.fillWidth: true
-                                            from: 0
-                                            to: 20
-                                            value: root.effectiveBackgroundBlur
-                                            suffix: " px"
-                                            onEdited: function (value) { root.backgroundBlurPreview = value; }
-                                            onCommitted: function (value) {
-                                                root.backgroundBlurPreview = Math.round(value);
-                                                root.setBackgroundBlur(value);
-                                            }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Dim"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        SettingSlider {
-                                            Layout.fillWidth: true
-                                            from: 0
-                                            to: 90
-                                            value: root.effectiveBackgroundDim
-                                            suffix: "%"
-                                            onEdited: function (value) { root.backgroundDimPreview = value; }
-                                            onCommitted: function (value) {
-                                                root.backgroundDimPreview = Math.round(value);
-                                                root.setBackgroundDim(value);
-                                            }
-                                        }
-                                    }
-
-                                    Item { Layout.preferredHeight: Style.spacing.md }
-
-                                    Text {
-                                        text: "Hot corner"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.55
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Enabled"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingToggle {
-                                            checked: root.hotCornerEnabled
-                                            onToggled: function (checked) { root.setHotCornerEnabled(checked); }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Position"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingChoices {
-                                            value: root.hotCornerPosition
-                                            options: [
-                                                { label: "TL", value: "top-left" },
-                                                { label: "TR", value: "top-right" },
-                                                { label: "BL", value: "bottom-left" },
-                                                { label: "BR", value: "bottom-right" }
+                                        Repeater {
+                                            id: settingsCategoryRepeater
+                                            model: [
+                                                "Appearance",
+                                                "Hot corner",
+                                                "Windows",
+                                                "Motion"
                                             ]
-                                            onChosen: function (value) { root.setHotCornerPosition(value); }
-                                        }
-                                    }
 
-                                    Item { Layout.fillHeight: true }
-
-                                    Text {
-                                        text: "Animation"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.55
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        spacing: Style.spacing.lg
-
-                                        SettingChoices {
-                                            value: root.animationStyle
-                                            options: [
-                                                { label: "Original", value: "original" },
-                                                { label: "Fade", value: "fade" },
-                                                { label: "Zoom", value: "zoom" },
-                                                { label: "Slide", value: "slide" }
-                                            ]
-                                            onChosen: function (value) {
-                                                root.clearAnimationTimingPreview();
-                                                root.setAnimationStyle(value);
-                                            }
-                                        }
-
-                                        Item { Layout.fillWidth: true }
-
-                                        DialogButton {
-                                            label: "Animate"
-                                            onClicked: root.previewAnimation()
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        visible: !root.animationTimingFor(root.animationStyle).separate
-
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Speed"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-
-                                        SettingSlider {
-                                            Layout.fillWidth: true
-                                            from: 100
-                                            to: 800
-                                            stepSize: 10
-                                            value: root.animationInDurationFor(root.animationStyle)
-                                            suffix: " ms"
-                                            onEdited: function (value) {
-                                                root.animationDurationPreviewStyle = root.animationStyle;
-                                                root.animationInDurationPreview = value;
-                                                root.animationOutDurationPreview = value;
-                                            }
-                                            onCommitted: function (value) {
-                                                var next = root.setAnimationDuration(root.animationStyle, value);
-                                                root.animationDurationPreviewStyle = root.animationStyle;
-                                                root.animationInDurationPreview = next;
-                                                root.animationOutDurationPreview = next;
+                                            delegate: SettingsCategoryButton {
+                                                required property int index
+                                                required property var modelData
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(settingsDialog.narrow ? 52 : 48)
+                                                categoryIndex: index
+                                                label: String(modelData)
+                                                selected: root.settingsCategoryIndex === index
+                                                horizontal: settingsDialog.narrow
+                                                onChosen: function (nextIndex) {
+                                                    root.settingsCategoryIndex = nextIndex;
+                                                    var nextButton = settingsCategoryRepeater.itemAt(nextIndex);
+                                                    if (nextButton)
+                                                        nextButton.forceActiveFocus();
+                                                }
                                             }
                                         }
                                     }
 
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        visible: root.animationTimingFor(root.animationStyle).separate
-
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "In"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-
-                                        SettingSlider {
-                                            Layout.fillWidth: true
-                                            from: 100
-                                            to: 800
-                                            stepSize: 10
-                                            value: root.animationInDurationFor(root.animationStyle)
-                                            suffix: " ms"
-                                            onEdited: function (value) {
-                                                root.animationDurationPreviewStyle = root.animationStyle;
-                                                root.animationInDurationPreview = value;
-                                            }
-                                            onCommitted: function (value) {
-                                                var next = root.setAnimationDurationIn(root.animationStyle, value);
-                                                root.animationDurationPreviewStyle = root.animationStyle;
-                                                root.animationInDurationPreview = next;
-                                            }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        visible: root.animationTimingFor(root.animationStyle).separate
-
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Out"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-
-                                        SettingSlider {
-                                            Layout.fillWidth: true
-                                            from: 100
-                                            to: 800
-                                            stepSize: 10
-                                            value: root.animationOutDurationFor(root.animationStyle)
-                                            suffix: " ms"
-                                            onEdited: function (value) {
-                                                root.animationDurationPreviewStyle = root.animationStyle;
-                                                root.animationOutDurationPreview = value;
-                                            }
-                                            onCommitted: function (value) {
-                                                var next = root.setAnimationDurationOut(root.animationStyle, value);
-                                                root.animationDurationPreviewStyle = root.animationStyle;
-                                                root.animationOutDurationPreview = next;
-                                            }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-
-                                        Text {
-                                            text: "Same speed in and out"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-
-                                        Item { Layout.fillWidth: true }
-
-                                        SettingToggle {
-                                            checked: !root.animationTimingFor(root.animationStyle).separate
-                                            onToggled: function (checked) {
-                                                root.clearAnimationTimingPreview();
-                                                root.setAnimationTimingSeparate(root.animationStyle, !checked);
-                                            }
-                                        }
+                                    Rectangle {
+                                        anchors.right: parent.right
+                                        anchors.bottom: parent.bottom
+                                        width: settingsDialog.narrow ? parent.width : Math.max(1, Style.normalBorderWidth)
+                                        height: settingsDialog.narrow ? Math.max(1, Style.normalBorderWidth) : parent.height
+                                        color: Color.menu.border
                                     }
                                 }
 
-                                ColumnLayout {
+                                Item {
+                                    id: settingsCategoryContent
                                     Layout.fillWidth: true
                                     Layout.fillHeight: true
+                                    clip: true
+
+                                    Item {
+                                        anchors.fill: parent
+                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                        visible: root.settingsCategoryIndex === 0
+                                        enabled: visible
+
+                                        ColumnLayout {
+                                            anchors.fill: parent
+                                            spacing: Style.spacing.md
+
+                                            ColumnLayout {
+                                                Layout.fillWidth: true
+                                                spacing: Style.spacing.xs
+
+                                                Text {
+                                                    text: "Appearance"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.accent
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.caption
+                                                    font.bold: true
+                                                    font.capitalization: Font.AllUppercase
+                                                }
+
+                                                Text {
+                                                    text: "Backdrop and footer"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.heading
+                                                    font.bold: true
+                                                }
+                                            }
+
+                                            Item { Layout.preferredHeight: Style.spacing.sm }
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Blur"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                SettingSlider {
+                                                    id: backgroundBlurSlider
+                                                    Layout.fillWidth: true
+                                                    from: 0
+                                                    to: 20
+                                                    value: root.effectiveBackgroundBlur
+                                                    suffix: " px"
+                                                    onEdited: function (value) { root.backgroundBlurPreview = value; }
+                                                    onCommitted: function (value) {
+                                                        root.backgroundBlurPreview = Math.round(value);
+                                                        root.setBackgroundBlur(value);
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Dim"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                SettingSlider {
+                                                    id: backgroundDimSlider
+                                                    Layout.fillWidth: true
+                                                    from: 0
+                                                    to: 90
+                                                    value: root.effectiveBackgroundDim
+                                                    suffix: "%"
+                                                    onEdited: function (value) { root.backgroundDimPreview = value; }
+                                                    onCommitted: function (value) {
+                                                        root.backgroundDimPreview = Math.round(value);
+                                                        root.setBackgroundDim(value);
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    text: "Bottom text"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingToggle {
+                                                    id: bottomTextToggle
+                                                    checked: root.showFooter
+                                                    onToggled: function (checked) {
+                                                        if (checked)
+                                                            root.updatePluginSetting("showFooter", true);
+                                                        else
+                                                            root.requestFooterHide();
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+                                            Item { Layout.fillHeight: true }
+                                        }
+                                    }
+
+                                    Item {
+                                        anchors.fill: parent
+                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                        visible: root.settingsCategoryIndex === 1
+                                        enabled: visible
+
+                                        ColumnLayout {
+                                            anchors.fill: parent
+                                            spacing: Style.spacing.md
+
+                                            ColumnLayout {
+                                                Layout.fillWidth: true
+                                                spacing: Style.spacing.xs
+
+                                                Text {
+                                                    text: "Hot corner"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.accent
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.caption
+                                                    font.bold: true
+                                                    font.capitalization: Font.AllUppercase
+                                                }
+
+                                                Text {
+                                                    text: "Overview activation"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.heading
+                                                    font.bold: true
+                                                }
+                                            }
+
+                                            Item { Layout.preferredHeight: Style.spacing.sm }
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    text: "Enabled"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingToggle {
+                                                    id: hotCornerToggle
+                                                    checked: root.hotCornerEnabled
+                                                    onToggled: function (checked) { root.setHotCornerEnabled(checked); }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Position"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: hotCornerPositionChoices
+                                                    value: root.hotCornerPosition
+                                                    options: [
+                                                        { label: "TL", value: "top-left" },
+                                                        { label: "TR", value: "top-right" },
+                                                        { label: "BL", value: "bottom-left" },
+                                                        { label: "BR", value: "bottom-right" }
+                                                    ]
+                                                    onChosen: function (value) { root.setHotCornerPosition(value); }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+                                            Item { Layout.fillHeight: true }
+                                        }
+                                    }
+
+                                    Item {
+                                        anchors.fill: parent
+                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                        visible: root.settingsCategoryIndex === 2
+                                        enabled: visible
+
+                                        ColumnLayout {
+                                            anchors.fill: parent
+                                            spacing: Style.spacing.md
+
+                                            ColumnLayout {
+                                                Layout.fillWidth: true
+                                                spacing: Style.spacing.xs
+
+                                                Text {
+                                                    text: "Windows"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.accent
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.caption
+                                                    font.bold: true
+                                                    font.capitalization: Font.AllUppercase
+                                                }
+
+                                                Text {
+                                                    text: "Window behavior"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.heading
+                                                    font.bold: true
+                                                }
+                                            }
+
+                                            Item { Layout.preferredHeight: Style.spacing.sm }
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Preview"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: previewPlacementChoices
+                                                    value: root.previewPlacement
+                                                    options: [
+                                                        { label: "In place", value: "in-place" },
+                                                        { label: "Centered", value: "centered" }
+                                                    ]
+                                                    onChosen: function (value) { root.setPreviewPlacement(value); }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Labels"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: windowFooterChoices
+                                                    value: root.windowFooterStyle
+                                                    spacing: Style.spacing.md
+                                                    options: [
+                                                        { label: "Floating", value: "floating" },
+                                                        { label: "Rail", value: "integrated" },
+                                                        { label: "Overlay", value: "overlay" },
+                                                        { label: "Centered", value: "centered" }
+                                                    ]
+                                                    onChosen: function (value) { root.setWindowFooterStyle(value); }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    text: "Move pointer"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingToggle {
+                                                    id: movePointerToggle
+                                                    checked: root.moveCursorToWindow
+                                                    onToggled: function (checked) { root.setMoveCursorToWindow(checked); }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(76)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Displays"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                DisplayModeChoices {
+                                                    id: displayModeChoicesControl
+                                                    Layout.fillWidth: true
+                                                    value: root.multiMonitorMode
+                                                    onChosen: function (value) { root.setMultiMonitorMode(value); }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+                                            Item { Layout.fillHeight: true }
+                                        }
+                                    }
+
+                                    Item {
+                                        anchors.fill: parent
+                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                        visible: root.settingsCategoryIndex === 3
+                                        enabled: visible
+
+                                        ColumnLayout {
+                                            anchors.fill: parent
+                                            spacing: Style.spacing.md
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                spacing: Style.spacing.lg
+
+                                                ColumnLayout {
+                                                    Layout.fillWidth: true
+                                                    spacing: Style.spacing.xs
+
+                                                    Text {
+                                                        text: "Motion"
+                                                        textFormat: Text.PlainText
+                                                        color: Color.accent
+                                                        font.family: Style.font.menuFamily
+                                                        font.pixelSize: Style.font.caption
+                                                        font.bold: true
+                                                        font.capitalization: Font.AllUppercase
+                                                    }
+
+                                                    Text {
+                                                        text: "Overview transition"
+                                                        textFormat: Text.PlainText
+                                                        color: Color.menu.text
+                                                        font.family: Style.font.menuFamily
+                                                        font.pixelSize: Style.font.heading
+                                                        font.bold: true
+                                                    }
+                                                }
+
+                                                DialogButton {
+                                                    id: motionAnimateButton
+                                                    label: "Animate"
+                                                    onClicked: root.previewAnimation()
+                                                }
+                                            }
+
+                                            Item { Layout.preferredHeight: Style.spacing.sm }
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Style"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: animationStyleChoices
+                                                    value: root.animationStyle
+                                                    options: [
+                                                        { label: "Original", value: "original" },
+                                                        { label: "Fade", value: "fade" },
+                                                        { label: "Zoom", value: "zoom" },
+                                                        { label: "Slide", value: "slide" }
+                                                    ]
+                                                    onChosen: function (value) {
+                                                        root.clearAnimationTimingPreview();
+                                                        root.setAnimationStyle(value);
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                visible: !root.animationTimingFor(root.animationStyle).separate
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Speed"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                SettingSlider {
+                                                    id: animationSpeedSlider
+                                                    Layout.fillWidth: true
+                                                    from: 100
+                                                    to: 800
+                                                    stepSize: 10
+                                                    value: root.animationInDurationFor(root.animationStyle)
+                                                    suffix: " ms"
+                                                    onEdited: function (value) {
+                                                        root.animationDurationPreviewStyle = root.animationStyle;
+                                                        root.animationInDurationPreview = value;
+                                                        root.animationOutDurationPreview = value;
+                                                    }
+                                                    onCommitted: function (value) {
+                                                        var next = root.setAnimationDuration(root.animationStyle, value);
+                                                        root.animationDurationPreviewStyle = root.animationStyle;
+                                                        root.animationInDurationPreview = next;
+                                                        root.animationOutDurationPreview = next;
+                                                    }
+                                                }
+                                            }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                visible: root.animationTimingFor(root.animationStyle).separate
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "In"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                SettingSlider {
+                                                    id: animationInSlider
+                                                    Layout.fillWidth: true
+                                                    from: 100
+                                                    to: 800
+                                                    stepSize: 10
+                                                    value: root.animationInDurationFor(root.animationStyle)
+                                                    suffix: " ms"
+                                                    onEdited: function (value) {
+                                                        root.animationDurationPreviewStyle = root.animationStyle;
+                                                        root.animationInDurationPreview = value;
+                                                    }
+                                                    onCommitted: function (value) {
+                                                        var next = root.setAnimationDurationIn(root.animationStyle, value);
+                                                        root.animationDurationPreviewStyle = root.animationStyle;
+                                                        root.animationInDurationPreview = next;
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider {
+                                                Layout.fillWidth: true
+                                                visible: root.animationTimingFor(root.animationStyle).separate
+                                            }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                visible: root.animationTimingFor(root.animationStyle).separate
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Out"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                SettingSlider {
+                                                    id: animationOutSlider
+                                                    Layout.fillWidth: true
+                                                    from: 100
+                                                    to: 800
+                                                    stepSize: 10
+                                                    value: root.animationOutDurationFor(root.animationStyle)
+                                                    suffix: " ms"
+                                                    onEdited: function (value) {
+                                                        root.animationDurationPreviewStyle = root.animationStyle;
+                                                        root.animationOutDurationPreview = value;
+                                                    }
+                                                    onCommitted: function (value) {
+                                                        var next = root.setAnimationDurationOut(root.animationStyle, value);
+                                                        root.animationDurationPreviewStyle = root.animationStyle;
+                                                        root.animationOutDurationPreview = next;
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                Text {
+                                                    text: "Same speed in and out"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingToggle {
+                                                    id: animationSameSpeedToggle
+                                                    checked: !root.animationTimingFor(root.animationStyle).separate
+                                                    onToggled: function (checked) {
+                                                        root.clearAnimationTimingPreview();
+                                                        root.setAnimationTimingSeparate(root.animationStyle, !checked);
+                                                    }
+                                                }
+                                            }
+
+                                            SettingsDivider { Layout.fillWidth: true }
+                                            Item { Layout.fillHeight: true }
+                                        }
+                                    }
+                                }
+                            }
+
+                            SettingsDivider { Layout.fillWidth: true }
+
+                            Item {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: Style.space(44)
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Style.space(24)
+                                    anchors.rightMargin: Style.space(24)
                                     spacing: Style.spacing.lg
 
                                     Text {
-                                        text: "Windows"
+                                        text: "Changes save immediately"
                                         textFormat: Text.PlainText
                                         color: Color.menu.text
-                                        opacity: 0.55
+                                        opacity: 0.45
                                         font.family: Style.font.menuFamily
                                         font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
                                     }
 
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Preview"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingChoices {
-                                            value: root.previewPlacement
-                                            options: [
-                                                { label: "In place", value: "in-place" },
-                                                { label: "Centered", value: "centered" }
-                                            ]
-                                            onChosen: function (value) { root.setPreviewPlacement(value); }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Labels"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingChoices {
-                                            value: root.windowFooterStyle
-                                            spacing: Style.spacing.md
-                                            options: [
-                                                { label: "Floating", value: "floating" },
-                                                { label: "Rail", value: "integrated" },
-                                                { label: "Overlay", value: "overlay" },
-                                                { label: "Centered", value: "centered" }
-                                            ]
-                                            onChosen: function (value) { root.setWindowFooterStyle(value); }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Move pointer"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingToggle {
-                                            checked: root.moveCursorToWindow
-                                            onToggled: function (checked) { root.setMoveCursorToWindow(checked); }
-                                        }
-                                    }
-
-                                    Item { Layout.preferredHeight: Style.spacing.md }
+                                    Item { Layout.fillWidth: true }
 
                                     Text {
-                                        text: "Multiple displays"
+                                        visible: !settingsDialog.narrow
+                                        text: "1–4 category   Tab controls"
                                         textFormat: Text.PlainText
                                         color: Color.menu.text
-                                        opacity: 0.55
+                                        opacity: 0.45
                                         font.family: Style.font.menuFamily
                                         font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
                                     }
-
-                                    DisplayModeChoices {
-                                        Layout.fillWidth: true
-                                        value: root.multiMonitorMode
-                                        onChosen: function (value) { root.setMultiMonitorMode(value); }
-                                    }
-
-                                    Item { Layout.preferredHeight: Style.spacing.md }
-
-                                    Text {
-                                        text: "Bottom text"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.55
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Visible"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingToggle {
-                                            id: bottomTextToggle
-                                            checked: root.showFooter
-                                            onToggled: function (checked) {
-                                                if (checked)
-                                                    root.updatePluginSetting("showFooter", true);
-                                                else
-                                                    root.requestFooterHide();
-                                            }
-                                        }
-                                    }
-
-                                    Item { Layout.fillHeight: true }
                                 }
                             }
                         }
                     }
-
                     Item {
                         id: footerHideConfirmationLayer
                         anchors.fill: parent
@@ -3126,7 +3640,7 @@ Item {
                             else if (!visible && root.settingsOpen && overviewWindow.acceptsKeyboard)
                                 Qt.callLater(function () {
                                     if (settingsLayer.visible && !footerHideConfirmationLayer.visible)
-                                        backgroundBlurSlider.forceActiveFocus();
+                                        bottomTextToggle.forceActiveFocus();
                                 });
                         }
 
@@ -3210,8 +3724,12 @@ Item {
                                     activeFocusOnTab: true
 
                                     Keys.onPressed: function (event) {
-                                        if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter)
+                                        if (root.handleSettingsTab(event))
                                             return;
+                                        if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
+                                            event.accepted = false;
+                                            return;
+                                        }
                                         root.footerHideAcknowledged = !root.footerHideAcknowledged;
                                         event.accepted = true;
                                     }
@@ -3272,11 +3790,13 @@ Item {
                                     Item { Layout.fillWidth: true }
 
                                     DialogButton {
+                                        id: footerHideCancelButton
                                         label: "Cancel"
                                         onClicked: root.closeFooterHideConfirmation()
                                     }
 
                                     DialogButton {
+                                        id: footerHideConfirmButton
                                         label: "Hide bottom text"
                                         destructive: true
                                         enabled: root.footerHideAcknowledged

--- a/Overview.qml
+++ b/Overview.qml
@@ -2707,6 +2707,119 @@ Item {
                                     spacing: Style.spacing.lg
 
                                     Text {
+                                        text: "Background"
+                                        textFormat: Text.PlainText
+                                        color: Color.menu.text
+                                        opacity: 0.55
+                                        font.family: Style.font.menuFamily
+                                        font.pixelSize: Style.font.caption
+                                        font.capitalization: Font.AllUppercase
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "Blur"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+                                        SettingSlider {
+                                            id: backgroundBlurSlider
+                                            Layout.fillWidth: true
+                                            from: 0
+                                            to: 20
+                                            value: root.effectiveBackgroundBlur
+                                            suffix: " px"
+                                            onEdited: function (value) { root.backgroundBlurPreview = value; }
+                                            onCommitted: function (value) {
+                                                root.backgroundBlurPreview = Math.round(value);
+                                                root.setBackgroundBlur(value);
+                                            }
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "Dim"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+                                        SettingSlider {
+                                            Layout.fillWidth: true
+                                            from: 0
+                                            to: 90
+                                            value: root.effectiveBackgroundDim
+                                            suffix: "%"
+                                            onEdited: function (value) { root.backgroundDimPreview = value; }
+                                            onCommitted: function (value) {
+                                                root.backgroundDimPreview = Math.round(value);
+                                                root.setBackgroundDim(value);
+                                            }
+                                        }
+                                    }
+
+                                    Item { Layout.preferredHeight: Style.spacing.md }
+
+                                    Text {
+                                        text: "Hot corner"
+                                        textFormat: Text.PlainText
+                                        color: Color.menu.text
+                                        opacity: 0.55
+                                        font.family: Style.font.menuFamily
+                                        font.pixelSize: Style.font.caption
+                                        font.capitalization: Font.AllUppercase
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "Enabled"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+                                        Item { Layout.fillWidth: true }
+                                        SettingToggle {
+                                            checked: root.hotCornerEnabled
+                                            onToggled: function (checked) { root.setHotCornerEnabled(checked); }
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "Position"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+                                        Item { Layout.fillWidth: true }
+                                        SettingChoices {
+                                            value: root.hotCornerPosition
+                                            options: [
+                                                { label: "TL", value: "top-left" },
+                                                { label: "TR", value: "top-right" },
+                                                { label: "BL", value: "bottom-left" },
+                                                { label: "BR", value: "bottom-right" }
+                                            ]
+                                            onChosen: function (value) { root.setHotCornerPosition(value); }
+                                        }
+                                    }
+
+                                    Item { Layout.fillHeight: true }
+
+                                    Text {
                                         text: "Animation"
                                         textFormat: Text.PlainText
                                         color: Color.menu.text
@@ -2861,121 +2974,6 @@ Item {
                                             }
                                         }
                                     }
-
-                                    Item { Layout.preferredHeight: Style.spacing.md }
-
-                                    Text {
-                                        text: "Background"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.55
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Blur"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        SettingSlider {
-                                            id: backgroundBlurSlider
-                                            Layout.fillWidth: true
-                                            from: 0
-                                            to: 20
-                                            value: root.effectiveBackgroundBlur
-                                            suffix: " px"
-                                            onEdited: function (value) { root.backgroundBlurPreview = value; }
-                                            onCommitted: function (value) {
-                                                root.backgroundBlurPreview = Math.round(value);
-                                                root.setBackgroundBlur(value);
-                                            }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Dim"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        SettingSlider {
-                                            Layout.fillWidth: true
-                                            from: 0
-                                            to: 90
-                                            value: root.effectiveBackgroundDim
-                                            suffix: "%"
-                                            onEdited: function (value) { root.backgroundDimPreview = value; }
-                                            onCommitted: function (value) {
-                                                root.backgroundDimPreview = Math.round(value);
-                                                root.setBackgroundDim(value);
-                                            }
-                                        }
-                                    }
-
-                                    Item { Layout.preferredHeight: Style.spacing.md }
-
-                                    Text {
-                                        text: "Hot corner"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.55
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                        font.capitalization: Font.AllUppercase
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Enabled"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingToggle {
-                                            checked: root.hotCornerEnabled
-                                            onToggled: function (checked) { root.setHotCornerEnabled(checked); }
-                                        }
-                                    }
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        Text {
-                                            Layout.preferredWidth: Style.space(112)
-                                            text: "Position"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.body
-                                        }
-                                        Item { Layout.fillWidth: true }
-                                        SettingChoices {
-                                            value: root.hotCornerPosition
-                                            options: [
-                                                { label: "TL", value: "top-left" },
-                                                { label: "TR", value: "top-right" },
-                                                { label: "BL", value: "bottom-left" },
-                                                { label: "BR", value: "bottom-right" }
-                                            ]
-                                            onChosen: function (value) { root.setHotCornerPosition(value); }
-                                        }
-                                    }
-
-                                    Item { Layout.fillHeight: true }
                                 }
 
                                 ColumnLayout {

--- a/Overview.qml
+++ b/Overview.qml
@@ -28,6 +28,52 @@ Item {
         var style = String((root.pluginEntry && root.pluginEntry.windowFooterStyle) || "floating");
         return root.windowFooterStyles.indexOf(style) !== -1 ? style : "floating";
     }
+    readonly property var animationStyles: ["original", "fade", "zoom", "slide"]
+    readonly property string animationStyle: {
+        var style = String((root.pluginEntry && root.pluginEntry.animationStyle) || "original");
+        return root.animationStyles.indexOf(style) !== -1 ? style : "original";
+    }
+    readonly property var defaultAnimationDurations: ({ original: 190, fade: 400, zoom: 320, slide: 320 })
+    readonly property var animationTimings: {
+        var configuredTimings = root.pluginEntry && root.pluginEntry.animationTimings
+            && typeof root.pluginEntry.animationTimings === "object"
+            ? root.pluginEntry.animationTimings
+            : null;
+        var configuredDurations = root.pluginEntry && root.pluginEntry.animationDurations
+            && typeof root.pluginEntry.animationDurations === "object"
+            ? root.pluginEntry.animationDurations
+            : null;
+        var configured = configuredTimings || configuredDurations || {};
+        var legacyRaw = root.pluginEntry ? root.pluginEntry.animationDuration : undefined;
+        var legacy = legacyRaw === null || legacyRaw === undefined ? NaN : Number(legacyRaw);
+        function timingFor(style) {
+            var raw = configured[style];
+            var isObject = raw !== null && raw !== undefined && typeof raw === "object";
+            var scalar = raw === null || raw === undefined ? NaN : Number(raw);
+            var separate = isObject && raw.separate === true;
+            var inValue = isObject ? Number(raw["in"]) : scalar;
+            var outValue = isObject ? Number(raw["out"]) : scalar;
+            if (!isFinite(inValue) && isFinite(legacy))
+                inValue = legacy;
+            if (!isFinite(outValue) && isFinite(legacy))
+                outValue = legacy;
+            if (!isFinite(inValue))
+                inValue = root.defaultAnimationDurations[style];
+            if (!isFinite(outValue))
+                outValue = inValue;
+            return {
+                "in": root.clampAnimationDuration(inValue),
+                "out": root.clampAnimationDuration(outValue),
+                separate: separate
+            };
+        }
+        return {
+            original: timingFor("original"),
+            fade: timingFor("fade"),
+            zoom: timingFor("zoom"),
+            slide: timingFor("slide")
+        };
+    }
     readonly property real windowFooterHeight: root.windowFooterStyle === "overlay" ? 0 : Style.space(40)
     readonly property int backgroundBlur: {
         var raw = root.pluginEntry ? root.pluginEntry.backgroundBlur : undefined;
@@ -70,6 +116,9 @@ Item {
     property bool settingsOpen: false
     property bool footerHideConfirmationOpen: false
     property bool footerHideAcknowledged: false
+    property string animationDurationPreviewStyle: ""
+    property real animationInDurationPreview: -1
+    property real animationOutDurationPreview: -1
     property real backgroundBlurPreview: -1
     property real backgroundDimPreview: -1
     readonly property real effectiveBackgroundBlur: root.backgroundBlurPreview >= 0 ? root.backgroundBlurPreview : root.backgroundBlur
@@ -86,6 +135,12 @@ Item {
     property var pendingMonitorStates: []
     property bool clientSnapshotRejected: false
     property bool clientRefreshPending: false
+    property bool openingClientRefreshComplete: false
+    property bool backgroundBlurPrimed: false
+    property bool backgroundBlurFailed: false
+    property bool dismissNotifyShell: false
+    property real motionProgress: 0
+    property real motionTarget: 0
     property int modelRevision: 0
     property var sessionToplevels: []
     property var sessionAspectRatios: []
@@ -109,53 +164,69 @@ Item {
         root.selectedIndex = Math.max(0, root.filteredToplevels.indexOf(ToplevelManager.activeToplevel));
     }
 
+    onMotionProgressChanged: root.scheduleBackgroundBlurUpdate()
+
     onEffectiveBackgroundBlurChanged: {
-        if (!root.opened)
+        if (!root.surfaceMounted)
             return;
-        if (!backgroundBlurSession.running && root.effectiveBackgroundBlur > 0)
+        if (!backgroundBlurSession.running && root.effectiveBackgroundBlur > 0 && !root.backgroundBlurFailed) {
+            root.backgroundBlurPrimed = false;
             backgroundBlurSession.running = true;
-        else if (backgroundBlurSession.running && !backgroundBlurUpdate.running)
-            backgroundBlurUpdate.start();
+        } else {
+            root.scheduleBackgroundBlurUpdate();
+        }
     }
 
     function open(payload) {
-        dismissTimer.stop();
-        dismissTimer.notifyShell = false;
         root.closeSettings();
         root.filterText = "";
         root.workspaceScope = "all";
-        var wasMounted = root.surfaceMounted;
-        if (!wasMounted)
-            root.resetSessionToplevels();
-        root.surfaceMounted = true;
-        root.selectedIndex = Math.max(0, root.filteredToplevels.indexOf(ToplevelManager.activeToplevel));
-        root.hoveredIndex = -1;
-        root.clearPreview();
-        if (wasMounted) {
+        root.dismissNotifyShell = false;
+        if (root.surfaceMounted) {
             root.opened = true;
+            root.animateMotionTo(1);
             root.refreshClients();
             Qt.callLater(root.focusKeyboardWindow);
             return;
         }
+        if (root.openingAfterClientRefresh)
+            return;
+        overviewMotionAnimation.stop();
+        root.motionTarget = 0;
+        root.motionProgress = 0;
+        root.resetSessionToplevels();
+        root.selectedIndex = Math.max(0, root.filteredToplevels.indexOf(ToplevelManager.activeToplevel));
+        root.hoveredIndex = -1;
+        root.clearPreview();
         root.openingAfterClientRefresh = true;
+        root.openingClientRefreshComplete = false;
+        root.backgroundBlurPrimed = false;
+        root.backgroundBlurFailed = false;
         root.refreshClients();
     }
 
     function close() {
-        if (root.surfaceMounted)
-            root.startDismiss(false);
-        else
-            root.opened = false;
+        root.startDismiss(false);
     }
 
     function startDismiss(notifyShell) {
         root.openingAfterClientRefresh = false;
+        root.openingClientRefreshComplete = false;
         root.closeSettings();
         root.hoveredIndex = -1;
         root.clearPreview();
         root.opened = false;
-        dismissTimer.notifyShell = notifyShell;
-        dismissTimer.restart();
+        root.dismissNotifyShell = root.dismissNotifyShell || notifyShell;
+        if (root.surfaceMounted) {
+            root.animateMotionTo(0);
+            return;
+        }
+        overviewMotionAnimation.stop();
+        root.motionTarget = 0;
+        root.motionProgress = 0;
+        root.backgroundBlurPrimed = false;
+        backgroundBlurSession.running = false;
+        root.finishDismiss();
     }
 
     function dismiss() {
@@ -164,6 +235,92 @@ Item {
 
     function toggle() {
         (root.opened || root.openingAfterClientRefresh) ? root.dismiss() : root.open("{}");
+    }
+
+    function requestedBackgroundBlur() {
+        if (root.effectiveBackgroundBlur <= 0 || root.motionProgress <= 0)
+            return 0;
+        return Math.max(1, Math.round(root.effectiveBackgroundBlur * root.motionProgress));
+    }
+
+    function scheduleBackgroundBlurUpdate() {
+        if (backgroundBlurSession.running && !backgroundBlurUpdate.running)
+            backgroundBlurUpdate.start();
+    }
+
+    function prepareOpenSurface() {
+        if (!root.openingAfterClientRefresh || !root.openingClientRefreshComplete)
+            return;
+        if (root.effectiveBackgroundBlur > 0 && !root.backgroundBlurFailed) {
+            if (!backgroundBlurSession.running) {
+                root.backgroundBlurPrimed = false;
+                backgroundBlurSession.running = true;
+                return;
+            }
+            if (!root.backgroundBlurPrimed)
+                return;
+        }
+        root.surfaceMounted = true;
+        Qt.callLater(function () {
+            if (!root.surfaceMounted || !root.openingAfterClientRefresh)
+                return;
+            root.openingAfterClientRefresh = false;
+            root.openingClientRefreshComplete = false;
+            root.opened = true;
+            root.animateMotionTo(1);
+            root.focusKeyboardWindow();
+        });
+    }
+
+    function animateMotionTo(target) {
+        var next = target >= 0.5 ? 1 : 0;
+        overviewMotionAnimation.stop();
+        root.motionTarget = next;
+        var distance = Math.abs(next - root.motionProgress);
+        if (distance < 0.001) {
+            root.motionProgress = next;
+            root.completeMotion();
+            return;
+        }
+        overviewMotionAnimation.from = root.motionProgress;
+        overviewMotionAnimation.to = next;
+        var configuredDuration = next > root.motionProgress
+            ? root.animationInDurationFor(root.animationStyle)
+            : root.animationOutDurationFor(root.animationStyle);
+        overviewMotionAnimation.duration = Math.max(1, Math.round(configuredDuration * distance));
+        overviewMotionAnimation.easing.type = root.animationStyle === "original"
+            ? Easing.OutQuart
+            : (next > root.motionProgress ? Easing.OutCubic : Easing.InCubic);
+        overviewMotionAnimation.start();
+    }
+
+    function previewAnimation() {
+        if (!root.surfaceMounted)
+            return;
+        overviewMotionAnimation.stop();
+        root.motionTarget = 1;
+        root.motionProgress = 0;
+        root.animateMotionTo(1);
+    }
+
+    function completeMotion() {
+        root.motionProgress = root.motionTarget;
+        root.scheduleBackgroundBlurUpdate();
+        if (root.motionTarget > 0) {
+            Qt.callLater(root.focusKeyboardWindow);
+            return;
+        }
+        root.surfaceMounted = false;
+        root.backgroundBlurPrimed = false;
+        backgroundBlurSession.running = false;
+        root.finishDismiss();
+    }
+
+    function finishDismiss() {
+        var notifyShell = root.dismissNotifyShell;
+        root.dismissNotifyShell = false;
+        if (notifyShell && root.shell && typeof root.shell.hide === "function")
+            root.shell.hide(root.pluginId);
     }
 
     function updatePluginSetting(name, value) {
@@ -190,6 +347,93 @@ Item {
             root.updatePluginSetting("windowFooterStyle", style);
     }
 
+    function setAnimationStyle(value) {
+        var style = root.animationStyles.indexOf(value) !== -1 ? value : "original";
+        if (style !== root.animationStyle)
+            root.updatePluginSetting("animationStyle", style);
+        return style;
+    }
+
+    function clampAnimationDuration(value) {
+        var numeric = Number(value);
+        if (!isFinite(numeric))
+            return 320;
+        var clamped = Math.max(100, Math.min(800, numeric));
+        return Math.round(clamped / 10) * 10;
+    }
+
+    function animationTimingFor(style) {
+        var mode = root.animationStyles.indexOf(style) !== -1 ? style : "original";
+        return root.animationTimings[mode];
+    }
+
+    function animationInDurationFor(style) {
+        if (root.animationInDurationPreview >= 0 && root.animationDurationPreviewStyle === style)
+            return root.animationInDurationPreview;
+        return Number(root.animationTimingFor(style)["in"]);
+    }
+
+    function animationOutDurationFor(style) {
+        if (root.animationOutDurationPreview >= 0 && root.animationDurationPreviewStyle === style)
+            return root.animationOutDurationPreview;
+        return Number(root.animationTimingFor(style)["out"]);
+    }
+
+    function setAnimationTiming(style, inValue, outValue, separate) {
+        var mode = root.animationStyles.indexOf(style) !== -1 ? style : "original";
+        var nextIn = root.clampAnimationDuration(inValue);
+        var nextOut = root.clampAnimationDuration(outValue);
+        var nextSeparate = separate === true;
+        var current = root.animationTimingFor(mode);
+        if (nextIn !== Number(current["in"])
+                || nextOut !== Number(current["out"])
+                || nextSeparate !== (current.separate === true)) {
+            var timings = {};
+            for (var index = 0; index < root.animationStyles.length; index++) {
+                var animationMode = root.animationStyles[index];
+                var timing = root.animationTimingFor(animationMode);
+                timings[animationMode] = animationMode === mode
+                    ? {"in": nextIn, "out": nextOut, separate: nextSeparate}
+                    : {"in": Number(timing["in"]), "out": Number(timing["out"]), separate: timing.separate === true};
+            }
+            root.updatePluginSetting("animationTimings", timings);
+        }
+        return {"in": nextIn, "out": nextOut, separate: nextSeparate};
+    }
+
+    function setAnimationDuration(style, value) {
+        var next = root.clampAnimationDuration(value);
+        root.setAnimationTiming(style, next, next, false);
+        return next;
+    }
+
+    function setAnimationDurationIn(style, value) {
+        var timing = root.animationTimingFor(style);
+        var next = root.clampAnimationDuration(value);
+        root.setAnimationTiming(style, next, timing["out"], true);
+        return next;
+    }
+
+    function setAnimationDurationOut(style, value) {
+        var timing = root.animationTimingFor(style);
+        var next = root.clampAnimationDuration(value);
+        root.setAnimationTiming(style, timing["in"], next, true);
+        return next;
+    }
+
+    function setAnimationTimingSeparate(style, separate) {
+        var timing = root.animationTimingFor(style);
+        return separate
+            ? root.setAnimationTiming(style, timing["in"], timing["out"], true)
+            : root.setAnimationTiming(style, timing["in"], timing["in"], false);
+    }
+
+    function clearAnimationTimingPreview() {
+        root.animationDurationPreviewStyle = "";
+        root.animationInDurationPreview = -1;
+        root.animationOutDurationPreview = -1;
+    }
+
     function setBackgroundBlur(value) {
         var numeric = Number(value);
         if (!isFinite(numeric))
@@ -214,6 +458,7 @@ Item {
         if (!root.surfaceMounted)
             root.open("{}");
         root.closeFooterHideConfirmation();
+        root.clearAnimationTimingPreview();
         root.backgroundBlurPreview = -1;
         root.backgroundDimPreview = -1;
         root.settingsOpen = true;
@@ -223,6 +468,7 @@ Item {
         var restoreKeyboardFocus = root.settingsOpen && root.opened;
         root.closeFooterHideConfirmation();
         root.settingsOpen = false;
+        root.clearAnimationTimingPreview();
         root.backgroundBlurPreview = -1;
         root.backgroundDimPreview = -1;
         if (restoreKeyboardFocus)
@@ -230,11 +476,6 @@ Item {
                 if (root.opened)
                     root.focusKeyboardWindow();
             });
-    }
-
-    onOpenedChanged: {
-        if (root.opened && root.effectiveBackgroundBlur > 0 && !backgroundBlurSession.running)
-            backgroundBlurSession.running = true;
     }
 
     function clearPreview() {
@@ -617,14 +858,9 @@ Item {
         root.pendingActiveWorkspaceName = "";
         root.pendingMonitorStates = [];
         if (!root.clientRefreshPending && root.openingAfterClientRefresh) {
-            root.openingAfterClientRefresh = false;
             root.captureSessionAspectRatios();
-            Qt.callLater(function () {
-                if (!root.surfaceMounted)
-                    return;
-                root.opened = true;
-                root.focusKeyboardWindow();
-            });
+            root.openingClientRefreshComplete = true;
+            root.prepareOpenSurface();
         }
         if (root.clientRefreshPending)
             Qt.callLater(root.refreshClients);
@@ -1151,25 +1387,19 @@ Item {
         }
     }
 
-    Timer {
-        id: dismissTimer
-        property bool notifyShell: false
-        interval: 190
-        onTriggered: {
-            root.surfaceMounted = false;
-            backgroundBlurSession.running = false;
-            if (notifyShell && root.shell && typeof root.shell.hide === "function")
-                root.shell.hide(root.pluginId);
-            notifyShell = false;
-        }
+    NumberAnimation {
+        id: overviewMotionAnimation
+        target: root
+        property: "motionProgress"
+        onFinished: root.completeMotion()
     }
 
     Timer {
         id: backgroundBlurUpdate
-        interval: 80
+        interval: 16
         onTriggered: {
             if (backgroundBlurSession.running)
-                backgroundBlurSession.write(String(Math.round(root.effectiveBackgroundBlur)) + "\n");
+                backgroundBlurSession.write(String(root.requestedBackgroundBlur()) + "\n");
         }
     }
 
@@ -1212,8 +1442,33 @@ Item {
         command: [root.pluginDir + "/background-blur-session"]
         stdinEnabled: true
         onStarted: {
-            if (!backgroundBlurUpdate.running)
-                backgroundBlurUpdate.start();
+            var initialBlur = root.openingAfterClientRefresh && root.effectiveBackgroundBlur > 0
+                ? 1
+                : root.requestedBackgroundBlur();
+            backgroundBlurSession.write(String(initialBlur) + "\n");
+        }
+        stdout: SplitParser {
+            onRead: function (line) {
+                var applied = Number(line);
+                if (!isFinite(applied))
+                    return;
+                if (applied < 0) {
+                    root.backgroundBlurFailed = true;
+                    root.prepareOpenSurface();
+                    return;
+                }
+                if (root.openingAfterClientRefresh) {
+                    root.backgroundBlurPrimed = true;
+                    root.prepareOpenSurface();
+                }
+            }
+        }
+        onExited: function (exitCode, exitStatus) {
+            root.backgroundBlurPrimed = false;
+            if (root.openingAfterClientRefresh) {
+                root.backgroundBlurFailed = true;
+                root.prepareOpenSurface();
+            }
         }
     }
 
@@ -1245,6 +1500,26 @@ Item {
                 return "expected floating, integrated, overlay, or centered";
             root.setWindowFooterStyle(style);
             return style;
+        }
+        function animationStyle(style: string): string {
+            if (root.animationStyles.indexOf(style) === -1)
+                return "expected original, fade, zoom, or slide";
+            return root.setAnimationStyle(style);
+        }
+        function animationDuration(style: string, value: real): string {
+            if (root.animationStyles.indexOf(style) === -1)
+                return "expected original, fade, zoom, or slide";
+            return String(root.setAnimationDuration(style, value));
+        }
+        function animationDurationIn(style: string, value: real): string {
+            if (root.animationStyles.indexOf(style) === -1)
+                return "expected original, fade, zoom, or slide";
+            return String(root.setAnimationDurationIn(style, value));
+        }
+        function animationDurationOut(style: string, value: real): string {
+            if (root.animationStyles.indexOf(style) === -1)
+                return "expected original, fade, zoom, or slide";
+            return String(root.setAnimationDurationOut(style, value));
         }
         function backgroundBlur(value: real): string {
             return String(root.setBackgroundBlur(value));
@@ -1306,7 +1581,11 @@ Item {
         function valueAt(position) {
             var availableWidth = Math.max(1, sliderTrackArea.width - sliderHandle.width);
             var normalized = Math.max(0, Math.min(1, (position - sliderHandle.width / 2) / availableWidth));
-            return settingSlider.from + normalized * (settingSlider.to - settingSlider.from);
+            var raw = settingSlider.from + normalized * (settingSlider.to - settingSlider.from);
+            if (settingSlider.stepSize <= 0)
+                return raw;
+            var stepped = settingSlider.from + Math.round((raw - settingSlider.from) / settingSlider.stepSize) * settingSlider.stepSize;
+            return Math.max(settingSlider.from, Math.min(settingSlider.to, stepped));
         }
 
         function commitKeyboardValue(nextValue) {
@@ -1720,7 +1999,11 @@ Item {
             exclusionMode: ExclusionMode.Ignore
             WlrLayershell.namespace: "expose-window-overview"
             WlrLayershell.layer: WlrLayer.Overlay
-            BackgroundEffect.blurRegion: root.effectiveBackgroundBlur > 0 ? backgroundBlurRegion : null
+            BackgroundEffect.blurRegion: root.effectiveBackgroundBlur > 0
+                    && root.motionProgress > 0
+                    && !root.backgroundBlurFailed
+                ? backgroundBlurRegion
+                : null
             property alias hotCornerHovered: openHotCorner.containsMouse
             readonly property bool acceptsKeyboard: {
                 var active = ToplevelManager.activeToplevel;
@@ -1745,12 +2028,7 @@ Item {
             Rectangle {
                 anchors.fill: parent
                 color: "black"
-                opacity: root.opened ? root.effectiveBackgroundDim / 100 : 0
-                Behavior on opacity {
-                    NumberAnimation {
-                        duration: 130
-                    }
-                }
+                opacity: root.motionProgress * root.effectiveBackgroundDim / 100
             }
 
             Item {
@@ -1758,20 +2036,19 @@ Item {
                 anchors.fill: parent
                 focus: overviewWindow.acceptsKeyboard
                 enabled: root.opened
-                opacity: root.opened ? 1 : 0
-                scale: root.opened ? 1 : 0.96
+                opacity: root.motionProgress
+                scale: root.animationStyle === "zoom"
+                    ? 0.82 + 0.18 * root.motionProgress
+                    : (root.animationStyle === "slide"
+                        ? 0.97 + 0.03 * root.motionProgress
+                        : (root.animationStyle === "original"
+                            ? 0.96 + 0.04 * root.motionProgress
+                            : 1))
                 transformOrigin: Item.Center
-                Behavior on opacity {
-                    NumberAnimation {
-                        duration: 190
-                        easing.type: Easing.OutQuart
-                    }
-                }
-                Behavior on scale {
-                    NumberAnimation {
-                        duration: 190
-                        easing.type: Easing.OutQuart
-                    }
+                transform: Translate {
+                    x: root.animationStyle === "slide"
+                        ? -overviewWindow.width * 0.11 * (1 - root.motionProgress)
+                        : 0
                 }
                 Keys.priority: Keys.BeforeItem
                 Keys.onPressed: function (event) {
@@ -1913,10 +2190,13 @@ Item {
                                     readonly property var packedRect: overviewArea.windowLayout[index] || Qt.rect(0, 0, 1, 1)
                                     readonly property var previewRect: root.previewRectFor(modelData, packedRect, overviewArea.width, overviewArea.height, Style.spacing.sm, root.windowFooterHeight)
                                     readonly property var layoutRect: previewed ? previewRect : packedRect
-                                    x: layoutRect.x
-                                    y: layoutRect.y
-                                    width: layoutRect.width
-                                    height: layoutRect.height
+                                    readonly property real originalMotionProgress: root.animationStyle === "original" && root.motionTarget > 0
+                                        ? root.motionProgress
+                                        : 1
+                                    x: layoutRect.x * originalMotionProgress
+                                    y: layoutRect.y * originalMotionProgress
+                                    width: layoutRect.width * originalMotionProgress
+                                    height: layoutRect.height * originalMotionProgress
                                     z: previewed ? 11 : (exitingPreview ? 10 : 0)
                                     radius: integratedFooter ? Style.cornerRadius : 0
                                     color: integratedFooter ? Color.menu.background : "transparent"
@@ -1924,30 +2204,35 @@ Item {
                                     border.width: integratedFooter ? outlineWidth : 0
                                     opacity: root.previewIndex < 0 || previewed ? 1 : 0.28
                                     Behavior on x {
+                                        enabled: root.motionProgress >= 0.999
                                         NumberAnimation {
                                             duration: root.previewAnimationDuration
                                             easing.type: root.previewAnimationEasing
                                         }
                                     }
                                     Behavior on y {
+                                        enabled: root.motionProgress >= 0.999
                                         NumberAnimation {
                                             duration: root.previewAnimationDuration
                                             easing.type: root.previewAnimationEasing
                                         }
                                     }
                                     Behavior on width {
+                                        enabled: root.motionProgress >= 0.999
                                         NumberAnimation {
                                             duration: root.previewAnimationDuration
                                             easing.type: root.previewAnimationEasing
                                         }
                                     }
                                     Behavior on height {
+                                        enabled: root.motionProgress >= 0.999
                                         NumberAnimation {
                                             duration: root.previewAnimationDuration
                                             easing.type: root.previewAnimationEasing
                                         }
                                     }
                                     Behavior on opacity {
+                                        enabled: root.motionProgress >= 0.999
                                         NumberAnimation {
                                             duration: root.previewFadeDuration
                                         }
@@ -1955,7 +2240,7 @@ Item {
 
                                     MouseArea {
                                         anchors.fill: parent
-                                        enabled: root.previewIndex < 0 || card.previewed
+                                        enabled: !root.settingsOpen && (root.previewIndex < 0 || card.previewed)
                                         hoverEnabled: true
                                         onEnabledChanged: {
                                             if (!enabled) {
@@ -2325,6 +2610,7 @@ Item {
                             opacity: settingsControl.hovered ? 1 : 0.7
                             font.family: Style.font.menuFamily
                             font.pixelSize: Style.font.bodySmall
+                            font.bold: true
 
                             MouseArea {
                                 anchors.fill: parent
@@ -2361,7 +2647,7 @@ Item {
                         readonly property bool narrow: width < Style.space(760)
                         anchors.centerIn: parent
                         width: Math.min(Style.space(920), parent.width - Style.space(80))
-                        height: Math.min(Style.space(narrow ? 800 : 500), parent.height - Style.space(80))
+                        height: Math.min(Style.space(narrow ? 1000 : 640), parent.height - Style.space(80))
                         radius: Style.cornerRadius
                         color: Color.menu.background
                         border.color: Color.menu.border
@@ -2419,6 +2705,164 @@ Item {
                                     Layout.fillWidth: true
                                     Layout.fillHeight: true
                                     spacing: Style.spacing.lg
+
+                                    Text {
+                                        text: "Animation"
+                                        textFormat: Text.PlainText
+                                        color: Color.menu.text
+                                        opacity: 0.55
+                                        font.family: Style.font.menuFamily
+                                        font.pixelSize: Style.font.caption
+                                        font.capitalization: Font.AllUppercase
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: Style.spacing.lg
+
+                                        SettingChoices {
+                                            value: root.animationStyle
+                                            options: [
+                                                { label: "Original", value: "original" },
+                                                { label: "Fade", value: "fade" },
+                                                { label: "Zoom", value: "zoom" },
+                                                { label: "Slide", value: "slide" }
+                                            ]
+                                            onChosen: function (value) {
+                                                root.clearAnimationTimingPreview();
+                                                root.setAnimationStyle(value);
+                                            }
+                                        }
+
+                                        Item { Layout.fillWidth: true }
+
+                                        DialogButton {
+                                            label: "Animate"
+                                            onClicked: root.previewAnimation()
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        visible: !root.animationTimingFor(root.animationStyle).separate
+
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "Speed"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+
+                                        SettingSlider {
+                                            Layout.fillWidth: true
+                                            from: 100
+                                            to: 800
+                                            stepSize: 10
+                                            value: root.animationInDurationFor(root.animationStyle)
+                                            suffix: " ms"
+                                            onEdited: function (value) {
+                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                root.animationInDurationPreview = value;
+                                                root.animationOutDurationPreview = value;
+                                            }
+                                            onCommitted: function (value) {
+                                                var next = root.setAnimationDuration(root.animationStyle, value);
+                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                root.animationInDurationPreview = next;
+                                                root.animationOutDurationPreview = next;
+                                            }
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        visible: root.animationTimingFor(root.animationStyle).separate
+
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "In"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+
+                                        SettingSlider {
+                                            Layout.fillWidth: true
+                                            from: 100
+                                            to: 800
+                                            stepSize: 10
+                                            value: root.animationInDurationFor(root.animationStyle)
+                                            suffix: " ms"
+                                            onEdited: function (value) {
+                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                root.animationInDurationPreview = value;
+                                            }
+                                            onCommitted: function (value) {
+                                                var next = root.setAnimationDurationIn(root.animationStyle, value);
+                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                root.animationInDurationPreview = next;
+                                            }
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        visible: root.animationTimingFor(root.animationStyle).separate
+
+                                        Text {
+                                            Layout.preferredWidth: Style.space(112)
+                                            text: "Out"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+
+                                        SettingSlider {
+                                            Layout.fillWidth: true
+                                            from: 100
+                                            to: 800
+                                            stepSize: 10
+                                            value: root.animationOutDurationFor(root.animationStyle)
+                                            suffix: " ms"
+                                            onEdited: function (value) {
+                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                root.animationOutDurationPreview = value;
+                                            }
+                                            onCommitted: function (value) {
+                                                var next = root.setAnimationDurationOut(root.animationStyle, value);
+                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                root.animationOutDurationPreview = next;
+                                            }
+                                        }
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+
+                                        Text {
+                                            text: "Same speed in and out"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.body
+                                        }
+
+                                        Item { Layout.fillWidth: true }
+
+                                        SettingToggle {
+                                            checked: !root.animationTimingFor(root.animationStyle).separate
+                                            onToggled: function (checked) {
+                                                root.clearAnimationTimingPreview();
+                                                root.setAnimationTimingSeparate(root.animationStyle, !checked);
+                                            }
+                                        }
+                                    }
+
+                                    Item { Layout.preferredHeight: Style.spacing.md }
 
                                     Text {
                                         text: "Background"
@@ -2654,21 +3098,13 @@ Item {
                                         Item { Layout.fillWidth: true }
                                         SettingToggle {
                                             id: bottomTextToggle
-                                            visible: root.showFooter
-                                            checked: true
+                                            checked: root.showFooter
                                             onToggled: function (checked) {
-                                                if (!checked)
+                                                if (checked)
+                                                    root.updatePluginSetting("showFooter", true);
+                                                else
                                                     root.requestFooterHide();
                                             }
-                                        }
-                                        Text {
-                                            visible: !root.showFooter
-                                            text: "Hidden in config"
-                                            textFormat: Text.PlainText
-                                            color: Color.menu.text
-                                            opacity: 0.45
-                                            font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.caption
                                         }
                                     }
 
@@ -2740,7 +3176,7 @@ Item {
 
                                 Text {
                                     Layout.fillWidth: true
-                                    text: "This also hides the Settings link. You will not be able to restore it from Exposé."
+                                    text: "This also hides the Settings link. You can turn it back on while this panel remains open."
                                     textFormat: Text.PlainText
                                     wrapMode: Text.WordWrap
                                     color: Color.menu.text
@@ -2759,7 +3195,7 @@ Item {
                                         id: recoveryText
                                         anchors.fill: parent
                                         anchors.margins: Style.space(12)
-                                        text: "To restore it, edit ~/.config/omarchy/shell.json and set showFooter to true in the expose.window-overview plugin entry."
+                                        text: "After closing Settings, restore it in ~/.config/omarchy/shell.json by setting showFooter to true in the expose.window-overview plugin entry."
                                         textFormat: Text.PlainText
                                         wrapMode: Text.WordWrap
                                         color: Color.menu.text
@@ -2813,7 +3249,7 @@ Item {
                                         Text {
                                             id: acknowledgementText
                                             Layout.fillWidth: true
-                                            text: "I understand that I will need to edit the config file to restore it."
+                                            text: "I understand that closing Settings while it is hidden requires editing the config."
                                             textFormat: Text.PlainText
                                             wrapMode: Text.WordWrap
                                             color: Color.menu.text

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ With **Same overview**, every display shows the same grid. With **Per monitor**,
 
 Open **Settings** from the footer while the overview is open. Changes apply immediately:
 
+- Opening animation: Original (default), Fade, Zoom, or Slide
+- Animation speed saved per mode, linked for in/out by default or expandable to separate timings
 - Background blur (0–20) and dim (0–90)
 - Preview placement: in-place or centered
 - Window footer style: floating, integrated, overlay, or centered
@@ -88,6 +90,10 @@ Every reversible setting is also scriptable:
 ```sh
 omarchy-shell expose toggle                      # also: open, close
 omarchy-shell expose settings toggle             # also: open, close
+omarchy-shell expose animationStyle original     # original | fade | zoom | slide
+omarchy-shell expose animationDuration original 190    # linked in/out, 100-800 ms
+omarchy-shell expose animationDurationIn original 190  # separate opening speed
+omarchy-shell expose animationDurationOut original 190 # separate closing speed
 omarchy-shell expose backgroundBlur 4            # 0-20
 omarchy-shell expose backgroundDim 6             # 0-90
 omarchy-shell expose previewPlacement in-place   # in-place | centered
@@ -98,7 +104,7 @@ omarchy-shell expose hotCornerPosition top-left  # top-left | top-right | bottom
 omarchy-shell expose moveCursorToWindow on       # on | off
 ```
 
-After hiding the bottom text, restore it by editing `~/.config/omarchy/shell.json` and setting `"showFooter": true` in the `expose.window-overview` plugin entry.
+After hiding the bottom text, you can restore it while Settings remains open. If you close Settings first, edit `~/.config/omarchy/shell.json` and set `"showFooter": true` in the `expose.window-overview` plugin entry.
 
 ## Security and system changes
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ With **Same overview**, every display shows the same grid. With **Per monitor**,
 
 ## Settings
 
-Open **Settings** from the footer while the overview is open. Changes apply immediately:
+Open **Settings** from the footer while the overview is open. It is fully keyboard driven: 1-4 jump to a section, Up/Down move between controls, Left/Right adjust the focused control, Space or Enter activate, Escape closes. Changes apply immediately:
 
 - Opening animation: Original (default), Fade, Zoom, or Slide
 - Animation speed saved per mode, linked for in/out by default or expandable to separate timings

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ With **Same overview**, every display shows the same grid. With **Per monitor**,
 
 ## Settings
 
-Open **Settings** from the footer while the overview is open. It is fully keyboard driven: 1-4 jump to a section, Up/Down move between controls, Left/Right adjust the focused control, Space or Enter activate, Escape closes. Changes apply immediately:
+Open **Settings** from the footer while the overview is open. It is fully keyboard driven: 1-4 jump to a section, Up/Down move between controls, Left/Right adjust sliders and choices, Space or Enter flip toggles and press buttons, Escape closes. Changes apply immediately:
 
 - Opening animation: Original (default), Fade, Zoom, or Slide
 - Animation speed saved per mode, linked for in/out by default or expandable to separate timings

--- a/background-blur-session
+++ b/background-blur-session
@@ -74,7 +74,12 @@ while IFS= read -r candidate; do
   [[ -n $requested_size ]] || continue
   if (( requested_size < 1 )); then
     retry_saved_blur || echo "expose: could not restore the previous Hyprland blur settings" >&2
+    printf '0\n'
     continue
   fi
-  run_hyprctl eval "hl.config({ decoration = { blur = { enabled = true, size = ${requested_size} } } })" >/dev/null || true
+  if run_hyprctl eval "hl.config({ decoration = { blur = { enabled = true, size = ${requested_size} } } })" >/dev/null; then
+    printf '%s\n' "$requested_size"
+  else
+    printf '%s\n' -1
+  fi
 done

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "expose.window-overview",
   "name": "Exposé",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Kristoffer Risanger (@kristofferR)",
   "license": "MIT",
   "description": "macOS-style Exposé for Omarchy: one key or a hot corner shows every open window as a live preview. Type to search, press Space to Quick Look, press Enter to launch.",


### PR DESCRIPTION
The overview transition applied blur and motion too abruptly, and its settings had grown difficult to navigate.

This adds Original, Fade, Zoom, and Slide modes with per-mode in/out timing, fixes staged blur updates, and redesigns Settings around keyboard-navigable Appearance, Hot corner, Windows, and Motion sections. The numbered section labels are direct 1–4 shortcuts.

Validation:
- qmllint Overview.qml
- bash syntax checks for helper scripts
- omarchy plugin validate .