### PR TITLE
fix: inhibit compositor shortcuts and workspace gestures while Exposé is open

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -178,11 +178,80 @@ Item {
         }
     }
 
+    // Hyprland binds defined through Omarchy's Lua API expose no command, only
+    // a description. Binds described as Exposé (the README convention) are
+    // treated as the toggle chord and close the overview from inside, since the
+    // shortcut inhibitor stops the compositor from firing them itself.
+    property var toggleShortcuts: []
+    readonly property var keyNamesByQtKey: ({
+        [Qt.Key_Space]: "space", [Qt.Key_Return]: "return", [Qt.Key_Enter]: "kp_enter",
+        [Qt.Key_Tab]: "tab", [Qt.Key_Backspace]: "backspace", [Qt.Key_Delete]: "delete",
+        [Qt.Key_Insert]: "insert", [Qt.Key_Home]: "home", [Qt.Key_End]: "end",
+        [Qt.Key_PageUp]: "prior", [Qt.Key_PageDown]: "next",
+        [Qt.Key_Up]: "up", [Qt.Key_Down]: "down", [Qt.Key_Left]: "left", [Qt.Key_Right]: "right",
+        [Qt.Key_QuoteLeft]: "grave", [Qt.Key_Minus]: "minus", [Qt.Key_Equal]: "equal",
+        [Qt.Key_Comma]: "comma", [Qt.Key_Period]: "period", [Qt.Key_Slash]: "slash",
+        [Qt.Key_Semicolon]: "semicolon", [Qt.Key_Apostrophe]: "apostrophe",
+        [Qt.Key_BracketLeft]: "bracketleft", [Qt.Key_BracketRight]: "bracketright",
+        [Qt.Key_Backslash]: "backslash",
+        [Qt.Key_F1]: "f1", [Qt.Key_F2]: "f2", [Qt.Key_F3]: "f3", [Qt.Key_F4]: "f4",
+        [Qt.Key_F5]: "f5", [Qt.Key_F6]: "f6", [Qt.Key_F7]: "f7", [Qt.Key_F8]: "f8",
+        [Qt.Key_F9]: "f9", [Qt.Key_F10]: "f10", [Qt.Key_F11]: "f11", [Qt.Key_F12]: "f12"
+    })
+
+    function parseToggleShortcuts(text) {
+        var binds;
+        try {
+            binds = JSON.parse(String(text || ""));
+        } catch (e) {
+            return [];
+        }
+        if (!Array.isArray(binds))
+            return [];
+        var result = [];
+        for (var index = 0; index < binds.length; index++) {
+            var bind = binds[index];
+            if (!bind || typeof bind !== "object" || bind.mouse === true)
+                continue;
+            if (!/expos/i.test(String(bind.description || "")))
+                continue;
+            var modmask = (Number(bind.modmask) || 0) & 77;
+            var key = String(bind.key || "").toLowerCase();
+            var keycode = Number(bind.keycode) || 0;
+            // A bare printable key would also collide with search typing.
+            if (modmask === 0 && key.length === 1)
+                continue;
+            result.push({ modmask: modmask, key: key, keycode: keycode });
+        }
+        return result;
+    }
+
+    function matchesToggleShortcut(event) {
+        if (!root.toggleShortcuts.length || event.isAutoRepeat)
+            return false;
+        var modmask = (event.modifiers & Qt.ShiftModifier ? 1 : 0)
+            | (event.modifiers & Qt.ControlModifier ? 4 : 0)
+            | (event.modifiers & Qt.AltModifier ? 8 : 0)
+            | (event.modifiers & Qt.MetaModifier ? 64 : 0);
+        var text = String(event.text || "").toLowerCase();
+        var name = root.keyNamesByQtKey[event.key] || (text.length === 1 && text.charCodeAt(0) > 32 ? text : "");
+        for (var index = 0; index < root.toggleShortcuts.length; index++) {
+            var shortcut = root.toggleShortcuts[index];
+            if (shortcut.modmask !== modmask)
+                continue;
+            if (shortcut.keycode ? event.nativeScanCode === shortcut.keycode : (name && shortcut.key === name))
+                return true;
+        }
+        return false;
+    }
+
     function open(payload) {
         root.closeSettings();
         root.filterText = "";
         root.workspaceScope = "all";
         root.dismissNotifyShell = false;
+        if (!bindQuery.running)
+            bindQuery.running = true;
         if (root.surfaceMounted) {
             root.opened = true;
             root.animateMotionTo(1);
@@ -1495,6 +1564,14 @@ Item {
     }
 
     Process {
+        id: bindQuery
+        command: ["hyprctl", "binds", "-j"]
+        stdout: StdioCollector {
+            onStreamFinished: root.toggleShortcuts = root.parseToggleShortcuts(this.text)
+        }
+    }
+
+    Process {
         id: backgroundBlurSession
         command: [root.pluginDir + "/background-blur-session"]
         stdinEnabled: true
@@ -2369,6 +2446,11 @@ Item {
                 }
                 Keys.priority: Keys.BeforeItem
                 Keys.onPressed: function (event) {
+                    if (root.matchesToggleShortcut(event)) {
+                        root.dismiss();
+                        event.accepted = true;
+                        return;
+                    }
                     if (root.settingsOpen
                             && !root.footerHideConfirmationOpen
                             && event.key >= Qt.Key_1

--- a/Overview.qml
+++ b/Overview.qml
@@ -193,11 +193,15 @@ Item {
         [Qt.Key_Comma]: "comma", [Qt.Key_Period]: "period", [Qt.Key_Slash]: "slash",
         [Qt.Key_Semicolon]: "semicolon", [Qt.Key_Apostrophe]: "apostrophe",
         [Qt.Key_BracketLeft]: "bracketleft", [Qt.Key_BracketRight]: "bracketright",
-        [Qt.Key_Backslash]: "backslash",
-        [Qt.Key_F1]: "f1", [Qt.Key_F2]: "f2", [Qt.Key_F3]: "f3", [Qt.Key_F4]: "f4",
-        [Qt.Key_F5]: "f5", [Qt.Key_F6]: "f6", [Qt.Key_F7]: "f7", [Qt.Key_F8]: "f8",
-        [Qt.Key_F9]: "f9", [Qt.Key_F10]: "f10", [Qt.Key_F11]: "f11", [Qt.Key_F12]: "f12"
+        [Qt.Key_Backslash]: "backslash"
     })
+
+    function keyNameFor(event) {
+        if (event.key >= Qt.Key_F1 && event.key <= Qt.Key_F35)
+            return "f" + (event.key - Qt.Key_F1 + 1);
+        var text = String(event.text || "").toLowerCase();
+        return root.keyNamesByQtKey[event.key] || (text.length === 1 && text.charCodeAt(0) > 32 ? text : "");
+    }
 
     function parseToggleShortcuts(text) {
         var binds;
@@ -233,8 +237,7 @@ Item {
             | (event.modifiers & Qt.ControlModifier ? 4 : 0)
             | (event.modifiers & Qt.AltModifier ? 8 : 0)
             | (event.modifiers & Qt.MetaModifier ? 64 : 0);
-        var text = String(event.text || "").toLowerCase();
-        var name = root.keyNamesByQtKey[event.key] || (text.length === 1 && text.charCodeAt(0) > 32 ? text : "");
+        var name = root.keyNameFor(event);
         for (var index = 0; index < root.toggleShortcuts.length; index++) {
             var shortcut = root.toggleShortcuts[index];
             if (shortcut.modmask !== modmask)

--- a/Overview.qml
+++ b/Overview.qml
@@ -2224,6 +2224,12 @@ Item {
                 return active.screens[0].name === modelData.name;
             }
             WlrLayershell.keyboardFocus: root.opened && acceptsKeyboard ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+
+            ShortcutInhibitor {
+                window: overviewWindow
+                enabled: root.opened && overviewWindow.acceptsKeyboard
+            }
+
             property alias keyboardItem: keyCatcher
             readonly property var screenToplevels: {
                 var revision = root.modelRevision;

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ omarchy plugin add https://github.com/kristofferR/omarchy-expose.git --enable
 That's it: the top-left hot corner works right away. Optionally, bind a key in `~/.config/hypr/bindings.lua`, then run `hyprctl reload`:
 
 ```lua
-o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle")
+o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle", { dont_inhibit = true })
 ```
 
-Any unused chord works. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
+Any unused chord works. Keep `dont_inhibit` enabled so the same chord can close Exposé while its modal shortcut inhibitor is active. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ That's it: the top-left hot corner works right away. Optionally, bind a key in `
 o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle", { dont_inhibit = true })
 ```
 
-Any unused chord works. Keep `dont_inhibit` enabled so the same chord can close Exposé while its modal shortcut inhibitor is active. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
+Any unused chord works. While Exposé is open it inhibits compositor shortcuts and workspace gestures, so `dont_inhibit` lets the same chord close it again. Bindings described as "Exposé" (as above) also close it without that flag. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
 
 ### Update
 


### PR DESCRIPTION
Stacked on #4.

A workspace swipe or compositor shortcut still reaches Hyprland while the overview is open, so the workspace changes underneath it and then snaps back when the layer unmaps (see #3, closed by its author as the wrong approach).

The overview now registers a Wayland `ShortcutInhibitor` on its focused window, which Hyprland honours for binds and trackpad gestures. That also inhibits the user's own toggle chord, so:

- the README binding gains `dont_inhibit = true`, and
- binds described as "Exposé" (the README convention) are read from `hyprctl binds -j` and matched inside the overview, so existing bindings keep closing it without any config change. Lua-defined binds expose no command string, only a description, hence the match on description.

Tested live: a four-finger swipe changes workspace with Exposé closed and is swallowed with it open; ordinary Super chords are blocked; a bind described "Exposé" on Super+F12 and Super+F13 closes the overview; Escape and window activation still work.