### PR TITLE
feat: refine overview motion and input handling

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -455,14 +455,21 @@ Item {
 
     function setAnimationTimingSeparate(style, separate) {
         var timing = root.animationTimingFor(style);
+        if (style === "slide" && !separate)
+            root.setSlideDirection(root.slideDirection["in"]);
         return separate
             ? root.setAnimationTiming(style, timing["in"], timing["out"], true)
             : root.setAnimationTiming(style, timing["in"], timing["in"], false);
     }
 
+    function isSlideDirection(value) {
+        var direction = String(value === null || value === undefined ? "" : value);
+        return Object.prototype.hasOwnProperty.call(root.slideVectors, direction);
+    }
+
     function normalizeSlideDirection(value) {
         var direction = String(value === null || value === undefined ? "" : value);
-        return direction in root.slideVectors ? direction : "left";
+        return root.isSlideDirection(direction) ? direction : "left";
     }
 
     function setSlideDirections(inValue, outValue) {
@@ -1687,17 +1694,17 @@ Item {
             return String(root.setAnimationDurationOut(style, value));
         }
         function slideDirection(direction: string): string {
-            if (!(direction in root.slideVectors))
+            if (!root.isSlideDirection(direction))
                 return "expected left, right, up, or down";
             return root.setSlideDirection(direction);
         }
         function slideDirectionIn(direction: string): string {
-            if (!(direction in root.slideVectors))
+            if (!root.isSlideDirection(direction))
                 return "expected left, right, up, or down";
             return root.setSlideDirectionIn(direction);
         }
         function slideDirectionOut(direction: string): string {
-            if (!(direction in root.slideVectors))
+            if (!root.isSlideDirection(direction))
                 return "expected left, right, up, or down";
             return root.setSlideDirectionOut(direction);
         }

--- a/Overview.qml
+++ b/Overview.qml
@@ -207,83 +207,11 @@ Item {
         }
     }
 
-    // Hyprland binds defined through Omarchy's Lua API expose no command, only
-    // a description. Binds described as Exposé (the README convention) are
-    // treated as the toggle chord and close the overview from inside, since the
-    // shortcut inhibitor stops the compositor from firing them itself.
-    property var toggleShortcuts: []
-    readonly property var keyNamesByQtKey: ({
-        [Qt.Key_Space]: "space", [Qt.Key_Return]: "return", [Qt.Key_Enter]: "kp_enter",
-        [Qt.Key_Tab]: "tab", [Qt.Key_Backspace]: "backspace", [Qt.Key_Delete]: "delete",
-        [Qt.Key_Insert]: "insert", [Qt.Key_Home]: "home", [Qt.Key_End]: "end",
-        [Qt.Key_PageUp]: "prior", [Qt.Key_PageDown]: "next",
-        [Qt.Key_Up]: "up", [Qt.Key_Down]: "down", [Qt.Key_Left]: "left", [Qt.Key_Right]: "right",
-        [Qt.Key_QuoteLeft]: "grave", [Qt.Key_Minus]: "minus", [Qt.Key_Equal]: "equal",
-        [Qt.Key_Comma]: "comma", [Qt.Key_Period]: "period", [Qt.Key_Slash]: "slash",
-        [Qt.Key_Semicolon]: "semicolon", [Qt.Key_Apostrophe]: "apostrophe",
-        [Qt.Key_BracketLeft]: "bracketleft", [Qt.Key_BracketRight]: "bracketright",
-        [Qt.Key_Backslash]: "backslash"
-    })
-
-    function keyNameFor(event) {
-        if (event.key >= Qt.Key_F1 && event.key <= Qt.Key_F35)
-            return "f" + (event.key - Qt.Key_F1 + 1);
-        var text = String(event.text || "").toLowerCase();
-        return root.keyNamesByQtKey[event.key] || (text.length === 1 && text.charCodeAt(0) > 32 ? text : "");
-    }
-
-    function parseToggleShortcuts(text) {
-        var binds;
-        try {
-            binds = JSON.parse(String(text || ""));
-        } catch (e) {
-            return [];
-        }
-        if (!Array.isArray(binds))
-            return [];
-        var result = [];
-        for (var index = 0; index < binds.length; index++) {
-            var bind = binds[index];
-            if (!bind || typeof bind !== "object" || bind.mouse === true)
-                continue;
-            if (!/expos/i.test(String(bind.description || "")))
-                continue;
-            var modmask = (Number(bind.modmask) || 0) & 77;
-            var key = String(bind.key || "").toLowerCase();
-            var keycode = Number(bind.keycode) || 0;
-            // A bare printable key would also collide with search typing.
-            if (modmask === 0 && key.length === 1)
-                continue;
-            result.push({ modmask: modmask, key: key, keycode: keycode });
-        }
-        return result;
-    }
-
-    function matchesToggleShortcut(event) {
-        if (!root.toggleShortcuts.length || event.isAutoRepeat)
-            return false;
-        var modmask = (event.modifiers & Qt.ShiftModifier ? 1 : 0)
-            | (event.modifiers & Qt.ControlModifier ? 4 : 0)
-            | (event.modifiers & Qt.AltModifier ? 8 : 0)
-            | (event.modifiers & Qt.MetaModifier ? 64 : 0);
-        var name = root.keyNameFor(event);
-        for (var index = 0; index < root.toggleShortcuts.length; index++) {
-            var shortcut = root.toggleShortcuts[index];
-            if (shortcut.modmask !== modmask)
-                continue;
-            if (shortcut.keycode ? event.nativeScanCode === shortcut.keycode : (name && shortcut.key === name))
-                return true;
-        }
-        return false;
-    }
-
     function open(payload) {
         root.closeSettings();
         root.filterText = "";
         root.workspaceScope = "all";
         root.dismissNotifyShell = false;
-        if (!bindQuery.running)
-            bindQuery.running = true;
         if (root.surfaceMounted) {
             root.opened = true;
             root.animateMotionTo(1);
@@ -1673,14 +1601,6 @@ Item {
     }
 
     Process {
-        id: bindQuery
-        command: ["hyprctl", "binds", "-j"]
-        stdout: StdioCollector {
-            onStreamFinished: root.toggleShortcuts = root.parseToggleShortcuts(this.text)
-        }
-    }
-
-    Process {
         id: backgroundBlurSession
         command: [root.pluginDir + "/background-blur-session"]
         stdinEnabled: true
@@ -2428,11 +2348,6 @@ Item {
             }
             WlrLayershell.keyboardFocus: root.opened && acceptsKeyboard ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
 
-            ShortcutInhibitor {
-                window: overviewWindow
-                enabled: root.opened && overviewWindow.acceptsKeyboard
-            }
-
             property alias keyboardItem: keyCatcher
             readonly property var screenToplevels: {
                 var revision = root.modelRevision;
@@ -2592,11 +2507,6 @@ Item {
                 }
                 Keys.priority: Keys.BeforeItem
                 Keys.onPressed: function (event) {
-                    if (root.matchesToggleShortcut(event)) {
-                        root.dismiss();
-                        event.accepted = true;
-                        return;
-                    }
                     if (root.settingsOpen
                             && !root.footerHideConfirmationOpen
                             && event.key >= Qt.Key_1

--- a/Overview.qml
+++ b/Overview.qml
@@ -416,6 +416,8 @@ Item {
         var nextIn = root.clampAnimationDuration(inValue);
         var nextOut = root.clampAnimationDuration(outValue);
         var nextSeparate = separate === true;
+        if (mode === "slide" && !nextSeparate)
+            root.setSlideDirection(root.slideDirection["in"]);
         var current = root.animationTimingFor(mode);
         if (nextIn !== Number(current["in"])
                 || nextOut !== Number(current["out"])
@@ -455,8 +457,6 @@ Item {
 
     function setAnimationTimingSeparate(style, separate) {
         var timing = root.animationTimingFor(style);
-        if (style === "slide" && !separate)
-            root.setSlideDirection(root.slideDirection["in"]);
         return separate
             ? root.setAnimationTiming(style, timing["in"], timing["out"], true)
             : root.setAnimationTiming(style, timing["in"], timing["in"], false);

--- a/Overview.qml
+++ b/Overview.qml
@@ -74,6 +74,30 @@ Item {
             slide: timingFor("slide")
         };
     }
+    readonly property var slideVectors: ({
+        left: {x: -1, y: 0},
+        right: {x: 1, y: 0},
+        up: {x: 0, y: -1},
+        down: {x: 0, y: 1}
+    })
+    // {"in", "out"}. A bare string in config is shorthand for both. The slide
+    // timing's `separate` flag decides whether "out" is honored or mirrors "in".
+    readonly property var slideDirection: {
+        var raw = root.pluginEntry ? root.pluginEntry.slideDirection : undefined;
+        var isObject = raw !== null && raw !== undefined && typeof raw === "object";
+        var inValue = root.normalizeSlideDirection(isObject ? raw["in"] : raw);
+        var outValue = root.animationTimingFor("slide").separate
+            ? root.normalizeSlideDirection(isObject ? raw["out"] : raw)
+            : inValue;
+        return {"in": inValue, "out": outValue};
+    }
+    // Latched by animateMotionTo when a transition starts from rest, so reversing
+    // mid-flight slides back out the side it came from instead of popping across.
+    property string slideMotionDirection: ""
+    readonly property var slideVector: root.slideVectors[root.slideMotionDirection] || root.slideVectors[root.slideDirection["in"]]
+    readonly property real slideOffsetFraction: root.animationStyle === "slide"
+        ? 0.11 * (1 - root.motionProgress)
+        : 0
     readonly property real windowFooterHeight: root.windowFooterStyle === "overlay" ? 0 : Style.space(40)
     readonly property int backgroundBlur: {
         var raw = root.pluginEntry ? root.pluginEntry.backgroundBlur : undefined;
@@ -360,6 +384,8 @@ Item {
             root.completeMotion();
             return;
         }
+        if (root.motionProgress <= 0.001 || root.motionProgress >= 0.999)
+            root.slideMotionDirection = String(root.slideDirection[next > 0 ? "in" : "out"]);
         overviewMotionAnimation.from = root.motionProgress;
         overviewMotionAnimation.to = next;
         var configuredDuration = next > root.motionProgress
@@ -504,6 +530,40 @@ Item {
         return separate
             ? root.setAnimationTiming(style, timing["in"], timing["out"], true)
             : root.setAnimationTiming(style, timing["in"], timing["in"], false);
+    }
+
+    function normalizeSlideDirection(value) {
+        var direction = String(value === null || value === undefined ? "" : value);
+        return direction in root.slideVectors ? direction : "left";
+    }
+
+    function setSlideDirections(inValue, outValue) {
+        var nextIn = root.normalizeSlideDirection(inValue);
+        var nextOut = root.normalizeSlideDirection(outValue);
+        var current = root.slideDirection;
+        if (nextIn !== String(current["in"]) || nextOut !== String(current["out"]))
+            root.updatePluginSetting("slideDirection", {"in": nextIn, "out": nextOut});
+    }
+
+    function setSlideDirection(value) {
+        var next = root.normalizeSlideDirection(value);
+        root.setSlideDirections(next, next);
+        return next;
+    }
+
+    // Splitting a side also splits slide timing: one toggle governs both.
+    function setSlideDirectionIn(value) {
+        var next = root.normalizeSlideDirection(value);
+        root.setAnimationTimingSeparate("slide", true);
+        root.setSlideDirections(next, root.slideDirection["out"]);
+        return next;
+    }
+
+    function setSlideDirectionOut(value) {
+        var next = root.normalizeSlideDirection(value);
+        root.setAnimationTimingSeparate("slide", true);
+        root.setSlideDirections(root.slideDirection["in"], next);
+        return next;
     }
 
     function clearAnimationTimingPreview() {
@@ -1706,6 +1766,21 @@ Item {
                 return "expected original, fade, zoom, or slide";
             return String(root.setAnimationDurationOut(style, value));
         }
+        function slideDirection(direction: string): string {
+            if (!(direction in root.slideVectors))
+                return "expected left, right, up, or down";
+            return root.setSlideDirection(direction);
+        }
+        function slideDirectionIn(direction: string): string {
+            if (!(direction in root.slideVectors))
+                return "expected left, right, up, or down";
+            return root.setSlideDirectionIn(direction);
+        }
+        function slideDirectionOut(direction: string): string {
+            if (!(direction in root.slideVectors))
+                return "expected left, right, up, or down";
+            return root.setSlideDirectionOut(direction);
+        }
         function backgroundBlur(value: real): string {
             return String(root.setBackgroundBlur(value));
         }
@@ -2427,6 +2502,9 @@ Item {
                     categoryButton,
                     motionAnimateButton,
                     animationStyleChoices,
+                    slideDirectionChoices,
+                    slideDirectionInChoices,
+                    slideDirectionOutChoices,
                     animationSpeedSlider,
                     animationInSlider,
                     animationOutSlider,
@@ -2509,9 +2587,8 @@ Item {
                             : 1))
                 transformOrigin: Item.Center
                 transform: Translate {
-                    x: root.animationStyle === "slide"
-                        ? -overviewWindow.width * 0.11 * (1 - root.motionProgress)
-                        : 0
+                    x: overviewWindow.width * root.slideOffsetFraction * root.slideVector.x
+                    y: overviewWindow.height * root.slideOffsetFraction * root.slideVector.y
                 }
                 Keys.priority: Keys.BeforeItem
                 Keys.onPressed: function (event) {
@@ -3711,6 +3788,94 @@ Item {
                                             RowLayout {
                                                 Layout.fillWidth: true
                                                 Layout.preferredHeight: Style.space(48)
+                                                visible: root.animationStyle === "slide" && !root.animationTimingFor("slide").separate
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Direction"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: slideDirectionChoices
+                                                    value: String(root.slideDirection["in"])
+                                                    options: [
+                                                        { label: "Left", value: "left" },
+                                                        { label: "Right", value: "right" },
+                                                        { label: "Up", value: "up" },
+                                                        { label: "Down", value: "down" }
+                                                    ]
+                                                    onChosen: function (value) { root.setSlideDirection(value); }
+                                                }
+                                            }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "In from"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: slideDirectionInChoices
+                                                    value: String(root.slideDirection["in"])
+                                                    options: [
+                                                        { label: "Left", value: "left" },
+                                                        { label: "Right", value: "right" },
+                                                        { label: "Up", value: "up" },
+                                                        { label: "Down", value: "down" }
+                                                    ]
+                                                    onChosen: function (value) { root.setSlideDirectionIn(value); }
+                                                }
+                                            }
+
+                                            SettingsDivider {
+                                                Layout.fillWidth: true
+                                                visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
+                                            }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
+                                                visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
+                                                Text {
+                                                    Layout.preferredWidth: Style.space(120)
+                                                    text: "Out to"
+                                                    textFormat: Text.PlainText
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.body
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                SettingChoices {
+                                                    id: slideDirectionOutChoices
+                                                    value: String(root.slideDirection["out"])
+                                                    options: [
+                                                        { label: "Left", value: "left" },
+                                                        { label: "Right", value: "right" },
+                                                        { label: "Up", value: "up" },
+                                                        { label: "Down", value: "down" }
+                                                    ]
+                                                    onChosen: function (value) { root.setSlideDirectionOut(value); }
+                                                }
+                                            }
+
+                                            SettingsDivider {
+                                                Layout.fillWidth: true
+                                                visible: root.animationStyle === "slide"
+                                            }
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                Layout.preferredHeight: Style.space(48)
                                                 visible: !root.animationTimingFor(root.animationStyle).separate
                                                 Text {
                                                     Layout.preferredWidth: Style.space(120)
@@ -3817,7 +3982,7 @@ Item {
                                                 Layout.fillWidth: true
                                                 Layout.preferredHeight: Style.space(48)
                                                 Text {
-                                                    text: "Same speed in and out"
+                                                    text: "Same in and out"
                                                     textFormat: Text.PlainText
                                                     color: Color.menu.text
                                                     font.family: Style.font.menuFamily

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle")
 
 Any unused chord works. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
 
+To keep workspace swipes from changing the desktop behind Exposé, replace your workspace gesture in `~/.config/hypr/input.lua` with:
+
+```lua
+local expose_gesture_path = os.getenv("HOME") .. "/.config/omarchy/plugins/expose.window-overview/workspace-gesture.lua"
+local expose_gesture_loader = loadfile(expose_gesture_path)
+if expose_gesture_loader then
+  expose_gesture_loader()({ fingers = 4, scale = 0.5 })
+else
+  hl.gesture({ fingers = 4, direction = "horizontal", scale = 0.5, action = "workspace" })
+end
+```
+
+Adjust `fingers` and `scale` to match your preferred gesture. Only the workspace gesture is swallowed while Exposé is open; media keys and other compositor shortcuts keep working.
+
 ### Update
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ omarchy plugin add https://github.com/kristofferR/omarchy-expose.git --enable
 That's it: the top-left hot corner works right away. Optionally, bind a key in `~/.config/hypr/bindings.lua`, then run `hyprctl reload`:
 
 ```lua
-o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle", { dont_inhibit = true })
+o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle")
 ```
 
-Any unused chord works. While Exposé is open it inhibits compositor shortcuts and workspace gestures, so `dont_inhibit` lets the same chord close it again. Bindings described as "Exposé" (as above) also close it without that flag. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
+Any unused chord works. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Open **Settings** from the footer while the overview is open. It is fully keyboa
 
 - Opening animation: Original (default), Fade, Zoom, or Slide
 - Animation speed saved per mode, linked for in/out by default or expandable to separate timings
+- Slide direction: left (default), right, up, or down. Splitting in/out splits both speed and direction
 - Background blur (0–20) and dim (0–90)
 - Preview placement: in-place or centered
 - Window footer style: floating, integrated, overlay, or centered
@@ -94,6 +95,9 @@ omarchy-shell expose animationStyle original     # original | fade | zoom | slid
 omarchy-shell expose animationDuration original 190    # linked in/out, 100-800 ms
 omarchy-shell expose animationDurationIn original 190  # separate opening speed
 omarchy-shell expose animationDurationOut original 190 # separate closing speed
+omarchy-shell expose slideDirection left         # left | right | up | down, both halves
+omarchy-shell expose slideDirectionIn left       # separate opening side, also splits slide timing
+omarchy-shell expose slideDirectionOut right     # separate closing side, also splits slide timing
 omarchy-shell expose backgroundBlur 4            # 0-20
 omarchy-shell expose backgroundDim 6             # 0-90
 omarchy-shell expose previewPlacement in-place   # in-place | centered

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "expose.window-overview",
   "name": "Exposé",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Kristoffer Risanger (@kristofferR)",
   "license": "MIT",
   "description": "macOS-style Exposé for Omarchy: one key or a hot corner shows every open window as a live preview. Type to search, press Space to Quick Look, press Enter to launch.",

--- a/workspace-gesture.lua
+++ b/workspace-gesture.lua
@@ -1,0 +1,43 @@
+return function(options)
+  options = options or {}
+
+  local namespace = "expose-window-overview"
+  local expose_layers = #hl.get_layers({ namespace = namespace })
+  local workspace_gesture_enabled
+
+  local function register_gesture(action)
+    local gesture = {
+      fingers = options.fingers or 3,
+      direction = "horizontal",
+      action = action,
+    }
+    if options.scale ~= nil then gesture.scale = options.scale end
+
+    hl.gesture(gesture)
+  end
+
+  local function apply_gesture()
+    local enabled = expose_layers == 0
+    if enabled == workspace_gesture_enabled then return end
+
+    if workspace_gesture_enabled ~= nil then register_gesture("unset") end
+    workspace_gesture_enabled = enabled
+    register_gesture(enabled and "workspace" or function() end)
+  end
+
+  hl.on("layer.opened", function(layer)
+    if layer.namespace ~= namespace then return end
+
+    expose_layers = expose_layers + 1
+    apply_gesture()
+  end)
+
+  hl.on("layer.closed", function(layer)
+    if layer.namespace ~= namespace then return end
+
+    expose_layers = math.max(0, expose_layers - 1)
+    apply_gesture()
+  end)
+
+  apply_gesture()
+end


### PR DESCRIPTION
The Slide transition only supported the left edge, while preventing workspace swipes relied on a broad shortcut inhibitor that also blocked media keys, screenshots, and other compositor shortcuts.

This adds configurable left, right, up, and down slide directions. Linked timing keeps the entry and exit sides together; splitting it exposes separate **In from** and **Out to** controls. The active side is latched during interrupted transitions so reversing remains continuous.

The broad shortcut inhibitor and its bind-parsing fallback are removed. An optional Hyprland Lua gesture guard now swallows only the workspace gesture while the Exposé layer is present, leaving every other global shortcut active.

Config: `slideDirection` accepts `{"in": "up", "out": "down"}` or a bare string for both. IPC: `slideDirection`, `slideDirectionIn`, and `slideDirectionOut`.

Validated with `qmllint Overview.qml`, `luac -p workspace-gesture.lua`, shell syntax checks for every helper, and `omarchy plugin validate .`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable slide directions for opening and closing the overview: left, right, up, or down.
  - Added separate in/out direction controls and IPC commands.
  - Added a workspace gesture that is disabled while the overview is open and restored when it closes.
  - Renamed the speed setting to “Same in and out.”

- **Documentation**
  - Updated installation, gesture configuration, settings, and IPC examples for the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->