### PR TITLE
perf: mount the overview on the focused display only

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -152,11 +152,39 @@ Item {
     property var sessionAspectRatios: []
     property var pendingAspectRatioToplevels: []
     readonly property var allToplevels: ToplevelManager.toplevels ? ToplevelManager.toplevels.values : []
+    property string focusedMonitorName: ""
+    property string overviewScreenName: ""
+    property bool overviewScreenPinned: false
     readonly property string keyboardScreenName: {
+        if (root.overviewScreenName)
+            return root.overviewScreenName;
+        if (root.focusedMonitorName)
+            return root.focusedMonitorName;
         var active = ToplevelManager.activeToplevel;
         if (active && active.screens && active.screens.length)
             return String(active.screens[0].name || "");
         return Quickshell.screens.length ? String(Quickshell.screens[0].name || "") : "";
+    }
+    // One overlay surface: the focused monitor, or the display whose hot
+    // corner opened Exposé. Instantiating on every enabled output duplicates
+    // screencopy captures and layer textures.
+    readonly property var mountedScreens: {
+        var screens = Quickshell.screens;
+        if (!root.surfaceMounted)
+            return [];
+        var wanted = String(root.overviewScreenName || "");
+        var match = [];
+        var fallback = [];
+        for (var index = 0; index < screens.length; index++) {
+            var screen = screens[index];
+            if (!screen)
+                continue;
+            if (!fallback.length)
+                fallback.push(screen);
+            if (wanted && String(screen.name || "") === wanted)
+                match.push(screen);
+        }
+        return match.length ? match : fallback;
     }
     readonly property var filteredToplevels: {
         var revision = root.modelRevision;
@@ -269,6 +297,8 @@ Item {
         }
         if (root.openingAfterClientRefresh)
             return;
+        if (!root.overviewScreenPinned)
+            root.overviewScreenName = root.keyboardScreenName;
         overviewMotionAnimation.stop();
         root.motionTarget = 0;
         root.motionProgress = 0;
@@ -304,6 +334,7 @@ Item {
         root.motionProgress = 0;
         root.backgroundBlurPrimed = false;
         backgroundBlurSession.running = false;
+        root.clearOverviewScreen();
         root.finishDismiss();
     }
 
@@ -338,6 +369,8 @@ Item {
             if (!root.backgroundBlurPrimed)
                 return;
         }
+        if (!root.overviewScreenPinned)
+            root.overviewScreenName = root.focusedMonitorName || root.keyboardScreenName;
         root.surfaceMounted = true;
         Qt.callLater(function () {
             if (!root.surfaceMounted || !root.openingAfterClientRefresh)
@@ -391,6 +424,7 @@ Item {
         root.surfaceMounted = false;
         root.backgroundBlurPrimed = false;
         backgroundBlurSession.running = false;
+        root.clearOverviewScreen();
         root.finishDismiss();
     }
 
@@ -624,11 +658,25 @@ Item {
         return false;
     }
 
-    function triggerHotCorner() {
+    function triggerHotCorner(screenName) {
         if (!root.hotCornerEnabled || !root.hotCornerArmed)
             return;
         root.hotCornerArmed = false;
-        root.toggle();
+        if (root.opened || root.openingAfterClientRefresh) {
+            root.dismiss();
+            return;
+        }
+        var name = String(screenName || "");
+        if (name) {
+            root.overviewScreenPinned = true;
+            root.overviewScreenName = name;
+        }
+        root.open("{}");
+    }
+
+    function clearOverviewScreen() {
+        root.overviewScreenPinned = false;
+        root.overviewScreenName = "";
     }
 
     function scheduleHotCornerRearm() {
@@ -736,6 +784,7 @@ Item {
             var b = right[index];
             if (a.id !== b.id
                     || a.name !== b.name
+                    || a.focused !== b.focused
                     || a.activeWorkspace.id !== b.activeWorkspace.id
                     || a.activeWorkspace.name !== b.activeWorkspace.name)
                 return false;
@@ -743,17 +792,32 @@ Item {
         return true;
     }
 
+    function focusedNameFromMonitors(monitors) {
+        var list = monitors || [];
+        for (var index = 0; index < list.length; index++) {
+            var monitor = list[index];
+            if (monitor && monitor.focused)
+                return String(monitor.name || "");
+        }
+        return list.length && list[0] ? String(list[0].name || "") : "";
+    }
+
     function applyDisplayState(id, name, monitors) {
         var nextId = Number(id) || 0;
         var nextName = String(name || "").slice(0, 128);
         var nextMonitors = monitors || [];
+        var nextFocused = root.focusedNameFromMonitors(nextMonitors);
         if (nextId === root.activeWorkspaceId
                 && nextName === root.activeWorkspaceName
+                && nextFocused === root.focusedMonitorName
                 && root.monitorStatesEqual(root.monitorStates, nextMonitors))
             return;
         root.activeWorkspaceId = nextId;
         root.activeWorkspaceName = nextName;
         root.monitorStates = nextMonitors;
+        root.focusedMonitorName = nextFocused;
+        if (!root.overviewScreenPinned && (!root.surfaceMounted || root.openingAfterClientRefresh))
+            root.overviewScreenName = nextFocused || root.keyboardScreenName;
         root.hoveredIndex = -1;
         root.clearPreview();
         root.modelRevision++;
@@ -911,6 +975,7 @@ Item {
                     monitors.push({
                         id: Number(monitor.id) || 0,
                         name: String(monitor.name || "").slice(0, 128),
+                        focused: monitor.focused === true,
                         activeWorkspace: {
                             id: Number(monitorWorkspace.id) || 0,
                             name: String(monitorWorkspace.name || "").slice(0, 128)
@@ -1954,12 +2019,12 @@ Item {
         readonly property var options: [
             {
                 label: "Same overview",
-                description: "Show every window on every display",
+                description: "Show every window on the focused display",
                 value: "mirrored"
             },
             {
                 label: "Per monitor",
-                description: "Keep windows on their own display",
+                description: "Show only windows from the focused display",
                 value: "per-monitor"
             }
         ]
@@ -2314,7 +2379,7 @@ Item {
                 anchors.fill: parent
                 hoverEnabled: true
                 acceptedButtons: Qt.NoButton
-                onEntered: root.triggerHotCorner()
+                onEntered: root.triggerHotCorner(String(modelData.name || ""))
                 onExited: root.scheduleHotCornerRearm()
             }
         }
@@ -2322,7 +2387,7 @@ Item {
 
     Variants {
         id: surfaceInstances
-        model: root.surfaceMounted ? Quickshell.screens : []
+        model: root.mountedScreens
 
         PanelWindow {
             id: overviewWindow
@@ -2346,10 +2411,10 @@ Item {
                 : null
             property alias hotCornerHovered: openHotCorner.containsMouse
             readonly property bool acceptsKeyboard: {
-                var active = ToplevelManager.activeToplevel;
-                if (!active || !active.screens || !active.screens.length)
-                    return Quickshell.screens.length > 0 && Quickshell.screens[0].name === modelData.name;
-                return active.screens[0].name === modelData.name;
+                var wanted = String(root.overviewScreenName || "");
+                if (wanted)
+                    return String(modelData.name || "") === wanted;
+                return true;
             }
             WlrLayershell.keyboardFocus: root.opened && acceptsKeyboard ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
 

--- a/Overview.qml
+++ b/Overview.qml
@@ -155,7 +155,27 @@ Item {
     property string focusedMonitorName: ""
     property string overviewScreenName: ""
     property bool overviewScreenPinned: false
+    readonly property var effectiveOverviewScreen: {
+        var screens = Quickshell.screens;
+        var wanted = String(root.overviewScreenName || "");
+        var fallback = null;
+        for (var index = 0; index < screens.length; index++) {
+            var screen = screens[index];
+            if (!screen)
+                continue;
+            if (!fallback)
+                fallback = screen;
+            if (wanted && String(screen.name || "") === wanted)
+                return screen;
+        }
+        return fallback;
+    }
+    readonly property string effectiveOverviewScreenName: root.effectiveOverviewScreen
+        ? String(root.effectiveOverviewScreen.name || "")
+        : ""
     readonly property string keyboardScreenName: {
+        if (root.effectiveOverviewScreenName && (root.surfaceMounted || root.overviewScreenName))
+            return root.effectiveOverviewScreenName;
         if (root.overviewScreenName)
             return root.overviewScreenName;
         if (root.focusedMonitorName)
@@ -169,22 +189,9 @@ Item {
     // corner opened Exposé. Instantiating on every enabled output duplicates
     // screencopy captures and layer textures.
     readonly property var mountedScreens: {
-        var screens = Quickshell.screens;
-        if (!root.surfaceMounted)
+        if (!root.surfaceMounted || !root.effectiveOverviewScreen)
             return [];
-        var wanted = String(root.overviewScreenName || "");
-        var match = [];
-        var fallback = [];
-        for (var index = 0; index < screens.length; index++) {
-            var screen = screens[index];
-            if (!screen)
-                continue;
-            if (!fallback.length)
-                fallback.push(screen);
-            if (wanted && String(screen.name || "") === wanted)
-                match.push(screen);
-        }
-        return match.length ? match : fallback;
+        return [root.effectiveOverviewScreen];
     }
     readonly property var filteredToplevels: {
         var revision = root.modelRevision;
@@ -2019,12 +2026,12 @@ Item {
         readonly property var options: [
             {
                 label: "Same overview",
-                description: "Show every window on the focused display",
+                description: "Show all windows together on the selected display",
                 value: "mirrored"
             },
             {
                 label: "Per monitor",
-                description: "Show only windows from the focused display",
+                description: "Show only the selected display's windows",
                 value: "per-monitor"
             }
         ]
@@ -2411,7 +2418,7 @@ Item {
                 : null
             property alias hotCornerHovered: openHotCorner.containsMouse
             readonly property bool acceptsKeyboard: {
-                var wanted = String(root.overviewScreenName || "");
+                var wanted = root.effectiveOverviewScreenName;
                 if (wanted)
                     return String(modelData.name || "") === wanted;
                 return true;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ macOS-style Exposé for Omarchy: one key or a hot corner shows every open window
 - **Live previews.** Cards are real screencopy views, so videos keep playing and terminals keep scrolling. The Omarchy desktop behind the grid stays live too.
 - **Quick Look.** Space enlarges any preview and restores it again. Shift+Space does it in slow motion, like the classic macOS Easter egg.
 - **Search.** Just start typing to filter windows by title or application.
-- **Workspace scope.** Press Tab to switch between every window and windows on the current workspace. Per-monitor mode evaluates the current workspace of the focused display.
+- **Workspace scope.** Press Tab to switch between every window and windows on the current workspace. Per-monitor mode evaluates the current workspace of the selected display.
 - **Multi-monitor layouts.** The overview opens only on the focused display (or the display whose hot corner was used). Same overview shows every window there; per monitor keeps that display's own windows.
 - **Built for Omarchy.** Runs inside Omarchy Shell, follows the active theme, and adds no packages, services, or daemons.
 - **Hot corner.** Toggle the overview by flinging the pointer into a corner (on by default, any corner, can be disabled).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ macOS-style Exposé for Omarchy: one key or a hot corner shows every open window
 - **Live previews.** Cards are real screencopy views, so videos keep playing and terminals keep scrolling. The Omarchy desktop behind the grid stays live too.
 - **Quick Look.** Space enlarges any preview and restores it again. Shift+Space does it in slow motion, like the classic macOS Easter egg.
 - **Search.** Just start typing to filter windows by title or application.
-- **Workspace scope.** Press Tab to switch between every window and windows on the current workspace. Per-monitor mode evaluates the current workspace separately for each display.
-- **Multi-monitor layouts.** Same overview mirrors the full overview on every display by default. Per monitor keeps windows on their own display.
+- **Workspace scope.** Press Tab to switch between every window and windows on the current workspace. Per-monitor mode evaluates the current workspace of the focused display.
+- **Multi-monitor layouts.** The overview opens only on the focused display (or the display whose hot corner was used). Same overview shows every window there; per monitor keeps that display's own windows.
 - **Built for Omarchy.** Runs inside Omarchy Shell, follows the active theme, and adds no packages, services, or daemons.
 - **Hot corner.** Toggle the overview by flinging the pointer into a corner (on by default, any corner, can be disabled).
 
@@ -69,7 +69,7 @@ Removal leaves nothing behind: Exposé keeps no files outside its plugin directo
 
 Clicking a card activates it; middle-clicking closes it. Activation moves the pointer to the chosen window by default; this is a setting, not a change to Hyprland's global cursor behavior.
 
-With **Same overview**, every display shows the same grid. With **Per monitor**, each display shows only its own windows; after pressing Tab, each display uses its own active workspace.
+The overlay is created on one display only. With **Same overview**, that display shows every window. With **Per monitor**, it shows only windows that already belong to that display; after pressing Tab, the current workspace is the one active on that display.
 
 ## Settings
 
@@ -80,7 +80,7 @@ Open **Settings** from the footer while the overview is open. It is fully keyboa
 - Background blur (0–20) and dim (0–90)
 - Preview placement: in-place or centered
 - Window footer style: floating, integrated, overlay, or centered
-- Multiple displays: Same overview (default) or Per monitor
+- Multiple displays: Same overview (all windows on the focused display) or Per monitor (that display's windows only)
 - Bottom text visibility. Hiding it requires confirmation and removes the Settings link
 - Hot corner on/off and position (disable the same corner in other hot-corner plugins to avoid overlap)
 - Move cursor to the activated window on/off

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Open **Settings** from the footer while the overview is open. It is fully keyboa
 - Background blur (0–20) and dim (0–90)
 - Preview placement: in-place or centered
 - Window footer style: floating, integrated, overlay, or centered
-- Multiple displays: Same overview (all windows on the focused display) or Per monitor (that display's windows only)
+- Multiple displays: Same overview (all windows together on the selected display) or Per monitor (only that display's windows)
 - Bottom text visibility. Hiding it requires confirmation and removes the Settings link
 - Hot corner on/off and position (disable the same corner in other hot-corner plugins to avoid overlap)
 - Move cursor to the activated window on/off

--- a/list-clients
+++ b/list-clients
@@ -27,6 +27,7 @@ timeout --signal=TERM --kill-after=1 2 hyprctl --batch "j/monitors; j/clients" |
         | {
             id: (if (.id | type) == "number" then .id else 0 end),
             name: (.name | bounded(128)),
+            focused: (.focused == true),
             activeWorkspace: (.activeWorkspace | workspace)
           }
       ]


### PR DESCRIPTION
Opening Exposé instantiated a fullscreen overlay, live screencopy cards, and layer textures on every enabled output. On a multi-monitor setup that duplicates the expensive work even though only one display is being used.

The overview now mounts a single surface:

- A keybind or IPC open uses Hyprland's focused monitor (`hyprctl` `focused`, already known to `list-clients`).
- A hot corner pins the display whose corner was hit, so flinging into a corner on an unfocused output still opens there.
- The chosen output is kept for the session; compositor focus changes while open do not remount.

**Same overview** still lists every window on that one display. **Per monitor** still filters to windows that already belong there. Settings copy and the README match the new behavior.

Tested live on a dual-head setup: overlay appears only on the focused monitor; hot-corner open follows the corner's display; other outputs keep their desktop. `qmllint Overview.qml`, `bash -n` on the helpers, and `omarchy plugin validate .` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The overview now opens on the focused monitor or the display that triggered a hot corner.
  * Hot-corner activation keeps the overview pinned to the triggering display until it is cleared.
  * Window and workspace views now reflect the selected display more accurately across multi-monitor setups.
  * Display updates now keep overview placement and keyboard focus aligned with the selected monitor.

* **Documentation**
  * Updated multi-monitor behavior documentation, including Same overview and Per monitor modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->