### PR TITLE
perf: reduce overview opening latency

### DIFF
--- a/Overview.qml
+++ b/Overview.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Effects
 import QtQuick.Layouts
 import Quickshell
+import Quickshell.Hyprland
 import Quickshell.Io
 import Quickshell.Wayland
 import qs.Commons
@@ -270,6 +271,8 @@ Item {
         root.backgroundBlurPrimed = false;
         root.backgroundBlurFailed = false;
         root.refreshClients();
+        if (root.effectiveBackgroundBlur > 0)
+            backgroundBlurSession.running = true;
     }
 
     function close() {
@@ -1661,7 +1664,6 @@ Item {
         interval: 5000
         repeat: true
         running: root.opened
-        triggeredOnStart: true
         onTriggered: root.refreshClients()
     }
 
@@ -1713,6 +1715,15 @@ Item {
                 root.backgroundBlurFailed = true;
                 root.prepareOpenSurface();
             }
+        }
+    }
+
+    // Let compositor keybinds reach the resident shell without spawning a CLI.
+    Connections {
+        target: Hyprland
+        function onRawEvent(event) {
+            if (event && event.name === "custom" && event.data === "expose.window-overview:toggle")
+                root.toggle();
         }
     }
 
@@ -2454,100 +2465,27 @@ Item {
             readonly property string screenScopeLabel: root.workspaceScopeLabelForScreen(String(modelData.name || ""))
 
             function focusSettingsCategory() {
-                var categoryButton = settingsCategoryRepeater.itemAt(root.settingsCategoryIndex);
-                if (categoryButton)
-                    categoryButton.forceActiveFocus();
-            }
-
-            function availableFocusItems(candidates) {
-                var items = [];
-                for (var index = 0; index < candidates.length; index++) {
-                    var candidate = candidates[index];
-                    if (candidate && candidate.visible && candidate.enabled)
-                        items.push(candidate);
-                }
-                return items;
-            }
-
-            function settingsFocusItems() {
-                var categoryButton = settingsCategoryRepeater.itemAt(root.settingsCategoryIndex);
-                if (root.settingsCategoryIndex === 0)
-                    return overviewWindow.availableFocusItems([
-                        categoryButton,
-                        backgroundBlurSlider,
-                        backgroundDimSlider,
-                        bottomTextToggle
-                    ]);
-                if (root.settingsCategoryIndex === 1)
-                    return overviewWindow.availableFocusItems([
-                        categoryButton,
-                        hotCornerToggle,
-                        hotCornerPositionChoices
-                    ]);
-                if (root.settingsCategoryIndex === 2)
-                    return overviewWindow.availableFocusItems([
-                        categoryButton,
-                        previewPlacementChoices,
-                        windowFooterChoices,
-                        movePointerToggle,
-                        displayModeChoicesControl
-                    ]);
-                return overviewWindow.availableFocusItems([
-                    categoryButton,
-                    motionAnimateButton,
-                    animationStyleChoices,
-                    slideDirectionChoices,
-                    slideDirectionInChoices,
-                    slideDirectionOutChoices,
-                    animationSpeedSlider,
-                    animationInSlider,
-                    animationOutSlider,
-                    animationSameSpeedToggle
-                ]);
-            }
-
-            function footerConfirmationFocusItems() {
-                return overviewWindow.availableFocusItems([
-                    footerHideAcknowledgement,
-                    footerHideCancelButton,
-                    footerHideConfirmButton
-                ]);
-            }
-
-            function moveFocus(items, forward, forwardFallbackIndex, wrap) {
-                if (!items.length)
-                    return;
-                var focusedIndex = -1;
-                for (var index = 0; index < items.length; index++) {
-                    if (items[index].activeFocus) {
-                        focusedIndex = index;
-                        break;
-                    }
-                }
-                var nextIndex;
-                if (focusedIndex < 0)
-                    nextIndex = forward ? Math.min(forwardFallbackIndex, items.length - 1) : items.length - 1;
-                else if (wrap)
-                    nextIndex = (focusedIndex + (forward ? 1 : items.length - 1)) % items.length;
-                else
-                    nextIndex = focusedIndex + (forward ? 1 : -1);
-                if (nextIndex < 0 || nextIndex >= items.length)
-                    return;
-                root.focusSettingsItem(items[nextIndex]);
+                var settings = settingsLayerLoader.item;
+                if (settings)
+                    settings.focusSettingsCategory();
             }
 
             function moveSettingsFocus(forward, wrap) {
-                overviewWindow.moveFocus(overviewWindow.settingsFocusItems(), forward, 1, wrap);
+                var settings = settingsLayerLoader.item;
+                if (settings)
+                    settings.moveSettingsFocus(forward, wrap);
             }
 
             function focusFirstSettingsControl() {
-                var items = overviewWindow.settingsFocusItems();
-                if (items.length > 1)
-                    root.focusSettingsItem(items[1]);
+                var settings = settingsLayerLoader.item;
+                if (settings)
+                    settings.focusFirstSettingsControl();
             }
 
             function moveFooterConfirmationFocus(forward, wrap) {
-                overviewWindow.moveFocus(overviewWindow.footerConfirmationFocusItems(), forward, 0, wrap);
+                var settings = settingsLayerLoader.item;
+                if (settings)
+                    settings.moveFooterConfirmationFocus(forward, wrap);
             }
 
             onAcceptsKeyboardChanged: {
@@ -3219,993 +3157,1097 @@ Item {
                     }
                 }
 
-                Item {
-                    id: settingsLayer
+                Loader {
+                    id: settingsLayerLoader
                     anchors.fill: parent
-                    visible: root.settingsOpen
+                    active: root.settingsOpen
                     z: 200
-                    onVisibleChanged: {
-                        if (visible && overviewWindow.acceptsKeyboard)
+                    onLoaded: {
+                        if (overviewWindow.acceptsKeyboard)
                             Qt.callLater(overviewWindow.focusSettingsCategory);
                     }
 
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: root.closeSettings()
-                    }
-
-                    Rectangle {
-                        id: settingsDialog
-                        readonly property bool narrow: width < Style.space(760)
-                        anchors.centerIn: parent
-                        width: Math.min(Style.space(920), parent.width - Style.space(80))
-                        height: Math.min(Style.space(narrow ? 720 : 640), parent.height - Style.space(80))
-                        radius: Style.cornerRadius
-                        color: Color.menu.background
-                        border.color: Color.menu.border
-                        border.width: Math.max(1, Style.normalBorderWidth)
-                        enabled: !root.footerHideConfirmationOpen
-
-                        MouseArea {
+                    sourceComponent: Component {
+                        Item {
+                            id: settingsLayer
                             anchors.fill: parent
-                            onClicked: function (mouse) { mouse.accepted = true; }
-                        }
 
-                        ColumnLayout {
-                            anchors.fill: parent
-                            spacing: 0
-
-                            Item {
-                                Layout.fillWidth: true
-                                Layout.preferredHeight: Style.space(66)
-
-                                RowLayout {
-                                    anchors.fill: parent
-                                    anchors.leftMargin: Style.space(24)
-                                    anchors.rightMargin: Style.space(24)
-                                    spacing: Style.spacing.lg
-
-                                    Text {
-                                        text: "Exposé settings"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.heading
-                                        font.bold: true
-                                    }
-
-                                    Item { Layout.fillWidth: true }
-
-                                    Text {
-                                        text: "1-4 section   ↑↓ move   ←→ adjust   Esc close"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.5
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                    }
+                            function availableFocusItems(candidates) {
+                                var items = [];
+                                for (var index = 0; index < candidates.length; index++) {
+                                    var candidate = candidates[index];
+                                    if (candidate && candidate.visible && candidate.enabled)
+                                        items.push(candidate);
                                 }
+                                return items;
                             }
 
-                            SettingsDivider { Layout.fillWidth: true }
-
-                            GridLayout {
-                                Layout.fillWidth: true
-                                Layout.fillHeight: true
-                                columns: settingsDialog.narrow ? 1 : 2
-                                columnSpacing: 0
-                                rowSpacing: 0
-
-                                Item {
-                                    Layout.fillWidth: settingsDialog.narrow
-                                    Layout.fillHeight: !settingsDialog.narrow
-                                    Layout.preferredWidth: settingsDialog.narrow ? 0 : Style.space(218)
-                                    Layout.preferredHeight: settingsDialog.narrow ? Style.space(54) : 0
-
-                                    GridLayout {
-                                        anchors.top: parent.top
-                                        anchors.left: parent.left
-                                        anchors.right: parent.right
-                                        columns: settingsDialog.narrow ? 4 : 1
-                                        columnSpacing: 0
-                                        rowSpacing: 0
-
-                                        Repeater {
-                                            id: settingsCategoryRepeater
-                                            model: [
-                                                "Appearance",
-                                                "Hot corner",
-                                                "Windows",
-                                                "Motion"
-                                            ]
-
-                                            delegate: SettingsCategoryButton {
-                                                required property int index
-                                                required property var modelData
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(settingsDialog.narrow ? 52 : 48)
-                                                categoryIndex: index
-                                                label: String(modelData)
-                                                selected: root.settingsCategoryIndex === index
-                                                horizontal: settingsDialog.narrow
-                                                onChosen: function (nextIndex) {
-                                                    root.settingsCategoryIndex = nextIndex;
-                                                    var nextButton = settingsCategoryRepeater.itemAt(nextIndex);
-                                                    if (nextButton)
-                                                        nextButton.forceActiveFocus();
-                                                }
-                                                onEntered: overviewWindow.focusFirstSettingsControl()
-                                            }
-                                        }
-                                    }
-
-                                    Rectangle {
-                                        anchors.right: parent.right
-                                        anchors.bottom: parent.bottom
-                                        width: settingsDialog.narrow ? parent.width : Math.max(1, Style.normalBorderWidth)
-                                        height: settingsDialog.narrow ? Math.max(1, Style.normalBorderWidth) : parent.height
-                                        color: Color.menu.border
-                                    }
-                                }
-
-                                Item {
-                                    id: settingsCategoryContent
-                                    Layout.fillWidth: true
-                                    Layout.fillHeight: true
-                                    clip: true
-
-                                    Item {
-                                        anchors.fill: parent
-                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
-                                        visible: root.settingsCategoryIndex === 0
-                                        enabled: visible
-
-                                        ColumnLayout {
-                                            anchors.fill: parent
-                                            spacing: Style.spacing.md
-
-                                            ColumnLayout {
-                                                Layout.fillWidth: true
-                                                spacing: Style.spacing.xs
-
-                                                Text {
-                                                    text: "Appearance"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.accent
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.caption
-                                                    font.bold: true
-                                                    font.capitalization: Font.AllUppercase
-                                                }
-
-                                                Text {
-                                                    text: "Backdrop and footer"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.heading
-                                                    font.bold: true
-                                                }
-                                            }
-
-                                            Item { Layout.preferredHeight: Style.spacing.sm }
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Blur"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                SettingSlider {
-                                                    id: backgroundBlurSlider
-                                                    Layout.fillWidth: true
-                                                    from: 0
-                                                    to: 20
-                                                    value: root.effectiveBackgroundBlur
-                                                    suffix: " px"
-                                                    onEdited: function (value) { root.backgroundBlurPreview = value; }
-                                                    onCommitted: function (value) {
-                                                        root.backgroundBlurPreview = Math.round(value);
-                                                        root.setBackgroundBlur(value);
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Dim"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                SettingSlider {
-                                                    id: backgroundDimSlider
-                                                    Layout.fillWidth: true
-                                                    from: 0
-                                                    to: 90
-                                                    value: root.effectiveBackgroundDim
-                                                    suffix: "%"
-                                                    onEdited: function (value) { root.backgroundDimPreview = value; }
-                                                    onCommitted: function (value) {
-                                                        root.backgroundDimPreview = Math.round(value);
-                                                        root.setBackgroundDim(value);
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    text: "Bottom text"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingToggle {
-                                                    id: bottomTextToggle
-                                                    checked: root.showFooter
-                                                    onToggled: function (checked) {
-                                                        if (checked)
-                                                            root.updatePluginSetting("showFooter", true);
-                                                        else
-                                                            root.requestFooterHide();
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-                                            Item { Layout.fillHeight: true }
-                                        }
-                                    }
-
-                                    Item {
-                                        anchors.fill: parent
-                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
-                                        visible: root.settingsCategoryIndex === 1
-                                        enabled: visible
-
-                                        ColumnLayout {
-                                            anchors.fill: parent
-                                            spacing: Style.spacing.md
-
-                                            ColumnLayout {
-                                                Layout.fillWidth: true
-                                                spacing: Style.spacing.xs
-
-                                                Text {
-                                                    text: "Hot corner"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.accent
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.caption
-                                                    font.bold: true
-                                                    font.capitalization: Font.AllUppercase
-                                                }
-
-                                                Text {
-                                                    text: "Overview activation"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.heading
-                                                    font.bold: true
-                                                }
-                                            }
-
-                                            Item { Layout.preferredHeight: Style.spacing.sm }
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    text: "Enabled"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingToggle {
-                                                    id: hotCornerToggle
-                                                    checked: root.hotCornerEnabled
-                                                    onToggled: function (checked) { root.setHotCornerEnabled(checked); }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Position"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: hotCornerPositionChoices
-                                                    value: root.hotCornerPosition
-                                                    options: [
-                                                        { label: "TL", value: "top-left" },
-                                                        { label: "TR", value: "top-right" },
-                                                        { label: "BL", value: "bottom-left" },
-                                                        { label: "BR", value: "bottom-right" }
-                                                    ]
-                                                    onChosen: function (value) { root.setHotCornerPosition(value); }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-                                            Item { Layout.fillHeight: true }
-                                        }
-                                    }
-
-                                    Item {
-                                        anchors.fill: parent
-                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
-                                        visible: root.settingsCategoryIndex === 2
-                                        enabled: visible
-
-                                        ColumnLayout {
-                                            anchors.fill: parent
-                                            spacing: Style.spacing.md
-
-                                            ColumnLayout {
-                                                Layout.fillWidth: true
-                                                spacing: Style.spacing.xs
-
-                                                Text {
-                                                    text: "Windows"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.accent
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.caption
-                                                    font.bold: true
-                                                    font.capitalization: Font.AllUppercase
-                                                }
-
-                                                Text {
-                                                    text: "Window behavior"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.heading
-                                                    font.bold: true
-                                                }
-                                            }
-
-                                            Item { Layout.preferredHeight: Style.spacing.sm }
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Preview"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: previewPlacementChoices
-                                                    value: root.previewPlacement
-                                                    options: [
-                                                        { label: "In place", value: "in-place" },
-                                                        { label: "Centered", value: "centered" }
-                                                    ]
-                                                    onChosen: function (value) { root.setPreviewPlacement(value); }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Labels"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: windowFooterChoices
-                                                    value: root.windowFooterStyle
-                                                    spacing: Style.spacing.md
-                                                    options: [
-                                                        { label: "Floating", value: "floating" },
-                                                        { label: "Rail", value: "integrated" },
-                                                        { label: "Overlay", value: "overlay" },
-                                                        { label: "Centered", value: "centered" }
-                                                    ]
-                                                    onChosen: function (value) { root.setWindowFooterStyle(value); }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    text: "Move pointer"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingToggle {
-                                                    id: movePointerToggle
-                                                    checked: root.moveCursorToWindow
-                                                    onToggled: function (checked) { root.setMoveCursorToWindow(checked); }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(76)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Displays"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                DisplayModeChoices {
-                                                    id: displayModeChoicesControl
-                                                    Layout.fillWidth: true
-                                                    value: root.multiMonitorMode
-                                                    onChosen: function (value) { root.setMultiMonitorMode(value); }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-                                            Item { Layout.fillHeight: true }
-                                        }
-                                    }
-
-                                    Item {
-                                        anchors.fill: parent
-                                        anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
-                                        visible: root.settingsCategoryIndex === 3
-                                        enabled: visible
-
-                                        ColumnLayout {
-                                            anchors.fill: parent
-                                            spacing: Style.spacing.md
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                spacing: Style.spacing.lg
-
-                                                ColumnLayout {
-                                                    Layout.fillWidth: true
-                                                    spacing: Style.spacing.xs
-
-                                                    Text {
-                                                        text: "Motion"
-                                                        textFormat: Text.PlainText
-                                                        color: Color.accent
-                                                        font.family: Style.font.menuFamily
-                                                        font.pixelSize: Style.font.caption
-                                                        font.bold: true
-                                                        font.capitalization: Font.AllUppercase
-                                                    }
-
-                                                    Text {
-                                                        text: "Overview transition"
-                                                        textFormat: Text.PlainText
-                                                        color: Color.menu.text
-                                                        font.family: Style.font.menuFamily
-                                                        font.pixelSize: Style.font.heading
-                                                        font.bold: true
-                                                    }
-                                                }
-
-                                                DialogButton {
-                                                    id: motionAnimateButton
-                                                    label: "Animate"
-                                                    onClicked: root.previewAnimation()
-                                                }
-                                            }
-
-                                            Item { Layout.preferredHeight: Style.spacing.sm }
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Style"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: animationStyleChoices
-                                                    value: root.animationStyle
-                                                    options: [
-                                                        { label: "Original", value: "original" },
-                                                        { label: "Fade", value: "fade" },
-                                                        { label: "Zoom", value: "zoom" },
-                                                        { label: "Slide", value: "slide" }
-                                                    ]
-                                                    onChosen: function (value) {
-                                                        root.clearAnimationTimingPreview();
-                                                        root.setAnimationStyle(value);
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                visible: root.animationStyle === "slide" && !root.animationTimingFor("slide").separate
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Direction"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: slideDirectionChoices
-                                                    value: String(root.slideDirection["in"])
-                                                    options: [
-                                                        { label: "Left", value: "left" },
-                                                        { label: "Right", value: "right" },
-                                                        { label: "Up", value: "up" },
-                                                        { label: "Down", value: "down" }
-                                                    ]
-                                                    onChosen: function (value) { root.setSlideDirection(value); }
-                                                }
-                                            }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "In from"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: slideDirectionInChoices
-                                                    value: String(root.slideDirection["in"])
-                                                    options: [
-                                                        { label: "Left", value: "left" },
-                                                        { label: "Right", value: "right" },
-                                                        { label: "Up", value: "up" },
-                                                        { label: "Down", value: "down" }
-                                                    ]
-                                                    onChosen: function (value) { root.setSlideDirectionIn(value); }
-                                                }
-                                            }
-
-                                            SettingsDivider {
-                                                Layout.fillWidth: true
-                                                visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
-                                            }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Out to"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingChoices {
-                                                    id: slideDirectionOutChoices
-                                                    value: String(root.slideDirection["out"])
-                                                    options: [
-                                                        { label: "Left", value: "left" },
-                                                        { label: "Right", value: "right" },
-                                                        { label: "Up", value: "up" },
-                                                        { label: "Down", value: "down" }
-                                                    ]
-                                                    onChosen: function (value) { root.setSlideDirectionOut(value); }
-                                                }
-                                            }
-
-                                            SettingsDivider {
-                                                Layout.fillWidth: true
-                                                visible: root.animationStyle === "slide"
-                                            }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                visible: !root.animationTimingFor(root.animationStyle).separate
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Speed"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                SettingSlider {
-                                                    id: animationSpeedSlider
-                                                    Layout.fillWidth: true
-                                                    from: 100
-                                                    to: 800
-                                                    stepSize: 10
-                                                    value: root.animationInDurationFor(root.animationStyle)
-                                                    suffix: " ms"
-                                                    onEdited: function (value) {
-                                                        root.animationDurationPreviewStyle = root.animationStyle;
-                                                        root.animationInDurationPreview = value;
-                                                        root.animationOutDurationPreview = value;
-                                                    }
-                                                    onCommitted: function (value) {
-                                                        var next = root.setAnimationDuration(root.animationStyle, value);
-                                                        root.animationDurationPreviewStyle = root.animationStyle;
-                                                        root.animationInDurationPreview = next;
-                                                        root.animationOutDurationPreview = next;
-                                                    }
-                                                }
-                                            }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                visible: root.animationTimingFor(root.animationStyle).separate
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "In"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                SettingSlider {
-                                                    id: animationInSlider
-                                                    Layout.fillWidth: true
-                                                    from: 100
-                                                    to: 800
-                                                    stepSize: 10
-                                                    value: root.animationInDurationFor(root.animationStyle)
-                                                    suffix: " ms"
-                                                    onEdited: function (value) {
-                                                        root.animationDurationPreviewStyle = root.animationStyle;
-                                                        root.animationInDurationPreview = value;
-                                                    }
-                                                    onCommitted: function (value) {
-                                                        var next = root.setAnimationDurationIn(root.animationStyle, value);
-                                                        root.animationDurationPreviewStyle = root.animationStyle;
-                                                        root.animationInDurationPreview = next;
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider {
-                                                Layout.fillWidth: true
-                                                visible: root.animationTimingFor(root.animationStyle).separate
-                                            }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                visible: root.animationTimingFor(root.animationStyle).separate
-                                                Text {
-                                                    Layout.preferredWidth: Style.space(120)
-                                                    text: "Out"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                SettingSlider {
-                                                    id: animationOutSlider
-                                                    Layout.fillWidth: true
-                                                    from: 100
-                                                    to: 800
-                                                    stepSize: 10
-                                                    value: root.animationOutDurationFor(root.animationStyle)
-                                                    suffix: " ms"
-                                                    onEdited: function (value) {
-                                                        root.animationDurationPreviewStyle = root.animationStyle;
-                                                        root.animationOutDurationPreview = value;
-                                                    }
-                                                    onCommitted: function (value) {
-                                                        var next = root.setAnimationDurationOut(root.animationStyle, value);
-                                                        root.animationDurationPreviewStyle = root.animationStyle;
-                                                        root.animationOutDurationPreview = next;
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-
-                                            RowLayout {
-                                                Layout.fillWidth: true
-                                                Layout.preferredHeight: Style.space(48)
-                                                Text {
-                                                    text: "Same in and out"
-                                                    textFormat: Text.PlainText
-                                                    color: Color.menu.text
-                                                    font.family: Style.font.menuFamily
-                                                    font.pixelSize: Style.font.body
-                                                }
-                                                Item { Layout.fillWidth: true }
-                                                SettingToggle {
-                                                    id: animationSameSpeedToggle
-                                                    checked: !root.animationTimingFor(root.animationStyle).separate
-                                                    onToggled: function (checked) {
-                                                        root.clearAnimationTimingPreview();
-                                                        root.setAnimationTimingSeparate(root.animationStyle, !checked);
-                                                    }
-                                                }
-                                            }
-
-                                            SettingsDivider { Layout.fillWidth: true }
-                                            Item { Layout.fillHeight: true }
-                                        }
-                                    }
-                                }
+                            function settingsFocusItems() {
+                                var categoryButton = settingsCategoryRepeater.itemAt(root.settingsCategoryIndex);
+                                if (root.settingsCategoryIndex === 0)
+                                    return settingsLayer.availableFocusItems([
+                                        categoryButton,
+                                        backgroundBlurSlider,
+                                        backgroundDimSlider,
+                                        bottomTextToggle
+                                    ]);
+                                if (root.settingsCategoryIndex === 1)
+                                    return settingsLayer.availableFocusItems([
+                                        categoryButton,
+                                        hotCornerToggle,
+                                        hotCornerPositionChoices
+                                    ]);
+                                if (root.settingsCategoryIndex === 2)
+                                    return settingsLayer.availableFocusItems([
+                                        categoryButton,
+                                        previewPlacementChoices,
+                                        windowFooterChoices,
+                                        movePointerToggle,
+                                        displayModeChoicesControl
+                                    ]);
+                                return settingsLayer.availableFocusItems([
+                                    categoryButton,
+                                    motionAnimateButton,
+                                    animationStyleChoices,
+                                    slideDirectionChoices,
+                                    slideDirectionInChoices,
+                                    slideDirectionOutChoices,
+                                    animationSpeedSlider,
+                                    animationInSlider,
+                                    animationOutSlider,
+                                    animationSameSpeedToggle
+                                ]);
                             }
 
-                            SettingsDivider { Layout.fillWidth: true }
+                            function footerConfirmationFocusItems() {
+                                return settingsLayer.availableFocusItems([
+                                    footerHideAcknowledgement,
+                                    footerHideCancelButton,
+                                    footerHideConfirmButton
+                                ]);
+                            }
 
-                            Item {
-                                Layout.fillWidth: true
-                                Layout.preferredHeight: Style.space(44)
-
-                                RowLayout {
-                                    anchors.fill: parent
-                                    anchors.leftMargin: Style.space(24)
-                                    anchors.rightMargin: Style.space(24)
-                                    spacing: Style.spacing.lg
-
-                                    Text {
-                                        text: "Changes save immediately"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.45
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                    }
-
-                                    Item { Layout.fillWidth: true }
-
-                                    Text {
-                                        visible: !settingsDialog.narrow
-                                        text: "1–4 category   Tab controls"
-                                        textFormat: Text.PlainText
-                                        color: Color.menu.text
-                                        opacity: 0.45
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
+                            function moveFocus(items, forward, forwardFallbackIndex, wrap) {
+                                if (!items.length)
+                                    return;
+                                var focusedIndex = -1;
+                                for (var index = 0; index < items.length; index++) {
+                                    if (items[index].activeFocus) {
+                                        focusedIndex = index;
+                                        break;
                                     }
                                 }
+                                var nextIndex;
+                                if (focusedIndex < 0)
+                                    nextIndex = forward ? Math.min(forwardFallbackIndex, items.length - 1) : items.length - 1;
+                                else if (wrap)
+                                    nextIndex = (focusedIndex + (forward ? 1 : items.length - 1)) % items.length;
+                                else
+                                    nextIndex = focusedIndex + (forward ? 1 : -1);
+                                if (nextIndex < 0 || nextIndex >= items.length)
+                                    return;
+                                root.focusSettingsItem(items[nextIndex]);
                             }
-                        }
-                    }
-                    Item {
-                        id: footerHideConfirmationLayer
-                        anchors.fill: parent
-                        visible: root.footerHideConfirmationOpen
-                        z: 10
-                        onVisibleChanged: {
-                            if (visible && overviewWindow.acceptsKeyboard)
-                                Qt.callLater(function () {
-                                    if (footerHideConfirmationLayer.visible)
-                                        footerHideAcknowledgement.forceActiveFocus();
-                                });
-                            else if (!visible && root.settingsOpen && overviewWindow.acceptsKeyboard)
-                                Qt.callLater(function () {
-                                    if (settingsLayer.visible && !footerHideConfirmationLayer.visible)
-                                        bottomTextToggle.forceActiveFocus();
-                                });
-                        }
 
-                        MouseArea {
-                            anchors.fill: parent
-                            onClicked: root.closeFooterHideConfirmation()
-                        }
+                            function focusSettingsCategory() {
+                                var categoryButton = settingsCategoryRepeater.itemAt(root.settingsCategoryIndex);
+                                if (categoryButton)
+                                    categoryButton.forceActiveFocus();
+                            }
 
-                        Rectangle {
-                            anchors.fill: parent
-                            color: "black"
-                            opacity: 0.72
-                        }
+                            function moveSettingsFocus(forward, wrap) {
+                                settingsLayer.moveFocus(settingsLayer.settingsFocusItems(), forward, 1, wrap);
+                            }
 
-                        Rectangle {
-                            id: footerHideDialog
-                            anchors.centerIn: parent
-                            width: Math.min(Style.space(560), parent.width - Style.space(80))
-                            height: Math.min(parent.height - Style.space(80), footerHideContent.implicitHeight + Style.space(56))
-                            radius: Style.cornerRadius
-                            color: Color.menu.background
-                            border.color: Color.menu.border
-                            border.width: Math.max(1, Style.normalBorderWidth)
+                            function focusFirstSettingsControl() {
+                                var items = settingsLayer.settingsFocusItems();
+                                if (items.length > 1)
+                                    root.focusSettingsItem(items[1]);
+                            }
+
+                            function moveFooterConfirmationFocus(forward, wrap) {
+                                settingsLayer.moveFocus(settingsLayer.footerConfirmationFocusItems(), forward, 0, wrap);
+                            }
 
                             MouseArea {
                                 anchors.fill: parent
-                                onClicked: function (mouse) { mouse.accepted = true; }
+                                onClicked: root.closeSettings()
                             }
 
-                            ColumnLayout {
-                                id: footerHideContent
-                                anchors.fill: parent
-                                anchors.margins: Style.space(28)
-                                spacing: Style.spacing.lg
+                            Rectangle {
+                                id: settingsDialog
+                                readonly property bool narrow: width < Style.space(760)
+                                anchors.centerIn: parent
+                                width: Math.min(Style.space(920), parent.width - Style.space(80))
+                                height: Math.min(Style.space(narrow ? 720 : 640), parent.height - Style.space(80))
+                                radius: Style.cornerRadius
+                                color: Color.menu.background
+                                border.color: Color.menu.border
+                                border.width: Math.max(1, Style.normalBorderWidth)
+                                enabled: !root.footerHideConfirmationOpen
 
-                                Text {
-                                    Layout.fillWidth: true
-                                    text: "Hide bottom text?"
-                                    textFormat: Text.PlainText
-                                    color: Color.menu.text
-                                    font.family: Style.font.menuFamily
-                                    font.pixelSize: Style.font.heading
-                                    font.bold: true
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: function (mouse) { mouse.accepted = true; }
                                 }
 
-                                Text {
-                                    Layout.fillWidth: true
-                                    text: "This also hides the Settings link. You can turn it back on while this panel remains open."
-                                    textFormat: Text.PlainText
-                                    wrapMode: Text.WordWrap
-                                    color: Color.menu.text
-                                    font.family: Style.font.menuFamily
-                                    font.pixelSize: Style.font.body
-                                }
+                                ColumnLayout {
+                                    anchors.fill: parent
+                                    spacing: 0
 
-                                Rectangle {
-                                    Layout.fillWidth: true
-                                    Layout.preferredHeight: recoveryText.implicitHeight + Style.space(24)
-                                    color: Color.background
-                                    border.color: Color.menu.border
-                                    border.width: Math.max(1, Style.normalBorderWidth)
+                                    Item {
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: Style.space(66)
 
-                                    Text {
-                                        id: recoveryText
-                                        anchors.fill: parent
-                                        anchors.margins: Style.space(12)
-                                        text: "After closing Settings, restore it in ~/.config/omarchy/shell.json by setting showFooter to true in the expose.window-overview plugin entry."
-                                        textFormat: Text.PlainText
-                                        wrapMode: Text.WordWrap
-                                        color: Color.menu.text
-                                        opacity: 0.72
-                                        font.family: Style.font.menuFamily
-                                        font.pixelSize: Style.font.caption
-                                    }
-                                }
-
-                                Item {
-                                    id: footerHideAcknowledgement
-                                    Layout.fillWidth: true
-                                    Layout.preferredHeight: Math.max(Style.space(40), acknowledgementText.implicitHeight)
-                                    activeFocusOnTab: true
-
-                                    Keys.onPressed: function (event) {
-                                        if (root.handleSettingsNavigation(event))
-                                            return;
-                                        if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
-                                            event.accepted = false;
-                                            return;
-                                        }
-                                        root.footerHideAcknowledged = !root.footerHideAcknowledged;
-                                        event.accepted = true;
-                                    }
-
-                                    RowLayout {
-                                        id: acknowledgementRow
-                                        anchors.fill: parent
-                                        spacing: Style.spacing.md
-
-                                        Rectangle {
-                                            Layout.preferredWidth: Style.space(18)
-                                            Layout.preferredHeight: Style.space(18)
-                                            color: root.footerHideAcknowledged ? Color.accent : "transparent"
-                                            border.color: footerHideAcknowledgement.activeFocus || root.footerHideAcknowledged
-                                                ? Color.accent
-                                                : Color.menu.border
-                                            border.width: footerHideAcknowledgement.activeFocus
-                                                ? Math.max(2, Style.focusBorderWidth)
-                                                : Math.max(1, Style.normalBorderWidth)
+                                        RowLayout {
+                                            anchors.fill: parent
+                                            anchors.leftMargin: Style.space(24)
+                                            anchors.rightMargin: Style.space(24)
+                                            spacing: Style.spacing.lg
 
                                             Text {
-                                                anchors.centerIn: parent
-                                                visible: root.footerHideAcknowledged
-                                                text: "✓"
+                                                text: "Exposé settings"
                                                 textFormat: Text.PlainText
-                                                color: Color.background
+                                                color: Color.menu.text
+                                                font.family: Style.font.menuFamily
+                                                font.pixelSize: Style.font.heading
+                                                font.bold: true
+                                            }
+
+                                            Item { Layout.fillWidth: true }
+
+                                            Text {
+                                                text: "1-4 section   ↑↓ move   ←→ adjust   Esc close"
+                                                textFormat: Text.PlainText
+                                                color: Color.menu.text
+                                                opacity: 0.5
                                                 font.family: Style.font.menuFamily
                                                 font.pixelSize: Style.font.caption
-                                                font.bold: true
+                                            }
+                                        }
+                                    }
+
+                                    SettingsDivider { Layout.fillWidth: true }
+
+                                    GridLayout {
+                                        Layout.fillWidth: true
+                                        Layout.fillHeight: true
+                                        columns: settingsDialog.narrow ? 1 : 2
+                                        columnSpacing: 0
+                                        rowSpacing: 0
+
+                                        Item {
+                                            Layout.fillWidth: settingsDialog.narrow
+                                            Layout.fillHeight: !settingsDialog.narrow
+                                            Layout.preferredWidth: settingsDialog.narrow ? 0 : Style.space(218)
+                                            Layout.preferredHeight: settingsDialog.narrow ? Style.space(54) : 0
+
+                                            GridLayout {
+                                                anchors.top: parent.top
+                                                anchors.left: parent.left
+                                                anchors.right: parent.right
+                                                columns: settingsDialog.narrow ? 4 : 1
+                                                columnSpacing: 0
+                                                rowSpacing: 0
+
+                                                Repeater {
+                                                    id: settingsCategoryRepeater
+                                                    model: [
+                                                        "Appearance",
+                                                        "Hot corner",
+                                                        "Windows",
+                                                        "Motion"
+                                                    ]
+
+                                                    delegate: SettingsCategoryButton {
+                                                        required property int index
+                                                        required property var modelData
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(settingsDialog.narrow ? 52 : 48)
+                                                        categoryIndex: index
+                                                        label: String(modelData)
+                                                        selected: root.settingsCategoryIndex === index
+                                                        horizontal: settingsDialog.narrow
+                                                        onChosen: function (nextIndex) {
+                                                            root.settingsCategoryIndex = nextIndex;
+                                                            var nextButton = settingsCategoryRepeater.itemAt(nextIndex);
+                                                            if (nextButton)
+                                                                nextButton.forceActiveFocus();
+                                                        }
+                                                        onEntered: overviewWindow.focusFirstSettingsControl()
+                                                    }
+                                                }
+                                            }
+
+                                            Rectangle {
+                                                anchors.right: parent.right
+                                                anchors.bottom: parent.bottom
+                                                width: settingsDialog.narrow ? parent.width : Math.max(1, Style.normalBorderWidth)
+                                                height: settingsDialog.narrow ? Math.max(1, Style.normalBorderWidth) : parent.height
+                                                color: Color.menu.border
                                             }
                                         }
 
-                                        Text {
-                                            id: acknowledgementText
+                                        Item {
+                                            id: settingsCategoryContent
                                             Layout.fillWidth: true
-                                            text: "I understand that closing Settings while it is hidden requires editing the config."
+                                            Layout.fillHeight: true
+                                            clip: true
+
+                                            Item {
+                                                anchors.fill: parent
+                                                anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                                visible: root.settingsCategoryIndex === 0
+                                                enabled: visible
+
+                                                ColumnLayout {
+                                                    anchors.fill: parent
+                                                    spacing: Style.spacing.md
+
+                                                    ColumnLayout {
+                                                        Layout.fillWidth: true
+                                                        spacing: Style.spacing.xs
+
+                                                        Text {
+                                                            text: "Appearance"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.accent
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.caption
+                                                            font.bold: true
+                                                            font.capitalization: Font.AllUppercase
+                                                        }
+
+                                                        Text {
+                                                            text: "Backdrop and footer"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.heading
+                                                            font.bold: true
+                                                        }
+                                                    }
+
+                                                    Item { Layout.preferredHeight: Style.spacing.sm }
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Blur"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        SettingSlider {
+                                                            id: backgroundBlurSlider
+                                                            Layout.fillWidth: true
+                                                            from: 0
+                                                            to: 20
+                                                            value: root.effectiveBackgroundBlur
+                                                            suffix: " px"
+                                                            onEdited: function (value) { root.backgroundBlurPreview = value; }
+                                                            onCommitted: function (value) {
+                                                                root.backgroundBlurPreview = Math.round(value);
+                                                                root.setBackgroundBlur(value);
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Dim"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        SettingSlider {
+                                                            id: backgroundDimSlider
+                                                            Layout.fillWidth: true
+                                                            from: 0
+                                                            to: 90
+                                                            value: root.effectiveBackgroundDim
+                                                            suffix: "%"
+                                                            onEdited: function (value) { root.backgroundDimPreview = value; }
+                                                            onCommitted: function (value) {
+                                                                root.backgroundDimPreview = Math.round(value);
+                                                                root.setBackgroundDim(value);
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            text: "Bottom text"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingToggle {
+                                                            id: bottomTextToggle
+                                                            checked: root.showFooter
+                                                            onToggled: function (checked) {
+                                                                if (checked)
+                                                                    root.updatePluginSetting("showFooter", true);
+                                                                else
+                                                                    root.requestFooterHide();
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+                                                    Item { Layout.fillHeight: true }
+                                                }
+                                            }
+
+                                            Item {
+                                                anchors.fill: parent
+                                                anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                                visible: root.settingsCategoryIndex === 1
+                                                enabled: visible
+
+                                                ColumnLayout {
+                                                    anchors.fill: parent
+                                                    spacing: Style.spacing.md
+
+                                                    ColumnLayout {
+                                                        Layout.fillWidth: true
+                                                        spacing: Style.spacing.xs
+
+                                                        Text {
+                                                            text: "Hot corner"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.accent
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.caption
+                                                            font.bold: true
+                                                            font.capitalization: Font.AllUppercase
+                                                        }
+
+                                                        Text {
+                                                            text: "Overview activation"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.heading
+                                                            font.bold: true
+                                                        }
+                                                    }
+
+                                                    Item { Layout.preferredHeight: Style.spacing.sm }
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            text: "Enabled"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingToggle {
+                                                            id: hotCornerToggle
+                                                            checked: root.hotCornerEnabled
+                                                            onToggled: function (checked) { root.setHotCornerEnabled(checked); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Position"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: hotCornerPositionChoices
+                                                            value: root.hotCornerPosition
+                                                            options: [
+                                                                { label: "TL", value: "top-left" },
+                                                                { label: "TR", value: "top-right" },
+                                                                { label: "BL", value: "bottom-left" },
+                                                                { label: "BR", value: "bottom-right" }
+                                                            ]
+                                                            onChosen: function (value) { root.setHotCornerPosition(value); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+                                                    Item { Layout.fillHeight: true }
+                                                }
+                                            }
+
+                                            Item {
+                                                anchors.fill: parent
+                                                anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                                visible: root.settingsCategoryIndex === 2
+                                                enabled: visible
+
+                                                ColumnLayout {
+                                                    anchors.fill: parent
+                                                    spacing: Style.spacing.md
+
+                                                    ColumnLayout {
+                                                        Layout.fillWidth: true
+                                                        spacing: Style.spacing.xs
+
+                                                        Text {
+                                                            text: "Windows"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.accent
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.caption
+                                                            font.bold: true
+                                                            font.capitalization: Font.AllUppercase
+                                                        }
+
+                                                        Text {
+                                                            text: "Window behavior"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.heading
+                                                            font.bold: true
+                                                        }
+                                                    }
+
+                                                    Item { Layout.preferredHeight: Style.spacing.sm }
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Preview"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: previewPlacementChoices
+                                                            value: root.previewPlacement
+                                                            options: [
+                                                                { label: "In place", value: "in-place" },
+                                                                { label: "Centered", value: "centered" }
+                                                            ]
+                                                            onChosen: function (value) { root.setPreviewPlacement(value); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Labels"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: windowFooterChoices
+                                                            value: root.windowFooterStyle
+                                                            spacing: Style.spacing.md
+                                                            options: [
+                                                                { label: "Floating", value: "floating" },
+                                                                { label: "Rail", value: "integrated" },
+                                                                { label: "Overlay", value: "overlay" },
+                                                                { label: "Centered", value: "centered" }
+                                                            ]
+                                                            onChosen: function (value) { root.setWindowFooterStyle(value); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            text: "Move pointer"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingToggle {
+                                                            id: movePointerToggle
+                                                            checked: root.moveCursorToWindow
+                                                            onToggled: function (checked) { root.setMoveCursorToWindow(checked); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(76)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Displays"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        DisplayModeChoices {
+                                                            id: displayModeChoicesControl
+                                                            Layout.fillWidth: true
+                                                            value: root.multiMonitorMode
+                                                            onChosen: function (value) { root.setMultiMonitorMode(value); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+                                                    Item { Layout.fillHeight: true }
+                                                }
+                                            }
+
+                                            Item {
+                                                anchors.fill: parent
+                                                anchors.margins: Style.space(settingsDialog.narrow ? 20 : 28)
+                                                visible: root.settingsCategoryIndex === 3
+                                                enabled: visible
+
+                                                ColumnLayout {
+                                                    anchors.fill: parent
+                                                    spacing: Style.spacing.md
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        spacing: Style.spacing.lg
+
+                                                        ColumnLayout {
+                                                            Layout.fillWidth: true
+                                                            spacing: Style.spacing.xs
+
+                                                            Text {
+                                                                text: "Motion"
+                                                                textFormat: Text.PlainText
+                                                                color: Color.accent
+                                                                font.family: Style.font.menuFamily
+                                                                font.pixelSize: Style.font.caption
+                                                                font.bold: true
+                                                                font.capitalization: Font.AllUppercase
+                                                            }
+
+                                                            Text {
+                                                                text: "Overview transition"
+                                                                textFormat: Text.PlainText
+                                                                color: Color.menu.text
+                                                                font.family: Style.font.menuFamily
+                                                                font.pixelSize: Style.font.heading
+                                                                font.bold: true
+                                                            }
+                                                        }
+
+                                                        DialogButton {
+                                                            id: motionAnimateButton
+                                                            label: "Animate"
+                                                            onClicked: root.previewAnimation()
+                                                        }
+                                                    }
+
+                                                    Item { Layout.preferredHeight: Style.spacing.sm }
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Style"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: animationStyleChoices
+                                                            value: root.animationStyle
+                                                            options: [
+                                                                { label: "Original", value: "original" },
+                                                                { label: "Fade", value: "fade" },
+                                                                { label: "Zoom", value: "zoom" },
+                                                                { label: "Slide", value: "slide" }
+                                                            ]
+                                                            onChosen: function (value) {
+                                                                root.clearAnimationTimingPreview();
+                                                                root.setAnimationStyle(value);
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        visible: root.animationStyle === "slide" && !root.animationTimingFor("slide").separate
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Direction"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: slideDirectionChoices
+                                                            value: String(root.slideDirection["in"])
+                                                            options: [
+                                                                { label: "Left", value: "left" },
+                                                                { label: "Right", value: "right" },
+                                                                { label: "Up", value: "up" },
+                                                                { label: "Down", value: "down" }
+                                                            ]
+                                                            onChosen: function (value) { root.setSlideDirection(value); }
+                                                        }
+                                                    }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "In from"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: slideDirectionInChoices
+                                                            value: String(root.slideDirection["in"])
+                                                            options: [
+                                                                { label: "Left", value: "left" },
+                                                                { label: "Right", value: "right" },
+                                                                { label: "Up", value: "up" },
+                                                                { label: "Down", value: "down" }
+                                                            ]
+                                                            onChosen: function (value) { root.setSlideDirectionIn(value); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider {
+                                                        Layout.fillWidth: true
+                                                        visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
+                                                    }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        visible: root.animationStyle === "slide" && root.animationTimingFor("slide").separate
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Out to"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingChoices {
+                                                            id: slideDirectionOutChoices
+                                                            value: String(root.slideDirection["out"])
+                                                            options: [
+                                                                { label: "Left", value: "left" },
+                                                                { label: "Right", value: "right" },
+                                                                { label: "Up", value: "up" },
+                                                                { label: "Down", value: "down" }
+                                                            ]
+                                                            onChosen: function (value) { root.setSlideDirectionOut(value); }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider {
+                                                        Layout.fillWidth: true
+                                                        visible: root.animationStyle === "slide"
+                                                    }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        visible: !root.animationTimingFor(root.animationStyle).separate
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Speed"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        SettingSlider {
+                                                            id: animationSpeedSlider
+                                                            Layout.fillWidth: true
+                                                            from: 100
+                                                            to: 800
+                                                            stepSize: 10
+                                                            value: root.animationInDurationFor(root.animationStyle)
+                                                            suffix: " ms"
+                                                            onEdited: function (value) {
+                                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                                root.animationInDurationPreview = value;
+                                                                root.animationOutDurationPreview = value;
+                                                            }
+                                                            onCommitted: function (value) {
+                                                                var next = root.setAnimationDuration(root.animationStyle, value);
+                                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                                root.animationInDurationPreview = next;
+                                                                root.animationOutDurationPreview = next;
+                                                            }
+                                                        }
+                                                    }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        visible: root.animationTimingFor(root.animationStyle).separate
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "In"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        SettingSlider {
+                                                            id: animationInSlider
+                                                            Layout.fillWidth: true
+                                                            from: 100
+                                                            to: 800
+                                                            stepSize: 10
+                                                            value: root.animationInDurationFor(root.animationStyle)
+                                                            suffix: " ms"
+                                                            onEdited: function (value) {
+                                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                                root.animationInDurationPreview = value;
+                                                            }
+                                                            onCommitted: function (value) {
+                                                                var next = root.setAnimationDurationIn(root.animationStyle, value);
+                                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                                root.animationInDurationPreview = next;
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider {
+                                                        Layout.fillWidth: true
+                                                        visible: root.animationTimingFor(root.animationStyle).separate
+                                                    }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        visible: root.animationTimingFor(root.animationStyle).separate
+                                                        Text {
+                                                            Layout.preferredWidth: Style.space(120)
+                                                            text: "Out"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        SettingSlider {
+                                                            id: animationOutSlider
+                                                            Layout.fillWidth: true
+                                                            from: 100
+                                                            to: 800
+                                                            stepSize: 10
+                                                            value: root.animationOutDurationFor(root.animationStyle)
+                                                            suffix: " ms"
+                                                            onEdited: function (value) {
+                                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                                root.animationOutDurationPreview = value;
+                                                            }
+                                                            onCommitted: function (value) {
+                                                                var next = root.setAnimationDurationOut(root.animationStyle, value);
+                                                                root.animationDurationPreviewStyle = root.animationStyle;
+                                                                root.animationOutDurationPreview = next;
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+
+                                                    RowLayout {
+                                                        Layout.fillWidth: true
+                                                        Layout.preferredHeight: Style.space(48)
+                                                        Text {
+                                                            text: "Same in and out"
+                                                            textFormat: Text.PlainText
+                                                            color: Color.menu.text
+                                                            font.family: Style.font.menuFamily
+                                                            font.pixelSize: Style.font.body
+                                                        }
+                                                        Item { Layout.fillWidth: true }
+                                                        SettingToggle {
+                                                            id: animationSameSpeedToggle
+                                                            checked: !root.animationTimingFor(root.animationStyle).separate
+                                                            onToggled: function (checked) {
+                                                                root.clearAnimationTimingPreview();
+                                                                root.setAnimationTimingSeparate(root.animationStyle, !checked);
+                                                            }
+                                                        }
+                                                    }
+
+                                                    SettingsDivider { Layout.fillWidth: true }
+                                                    Item { Layout.fillHeight: true }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    SettingsDivider { Layout.fillWidth: true }
+
+                                    Item {
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: Style.space(44)
+
+                                        RowLayout {
+                                            anchors.fill: parent
+                                            anchors.leftMargin: Style.space(24)
+                                            anchors.rightMargin: Style.space(24)
+                                            spacing: Style.spacing.lg
+
+                                            Text {
+                                                text: "Changes save immediately"
+                                                textFormat: Text.PlainText
+                                                color: Color.menu.text
+                                                opacity: 0.45
+                                                font.family: Style.font.menuFamily
+                                                font.pixelSize: Style.font.caption
+                                            }
+
+                                            Item { Layout.fillWidth: true }
+
+                                            Text {
+                                                visible: !settingsDialog.narrow
+                                                text: "1–4 category   Tab controls"
+                                                textFormat: Text.PlainText
+                                                color: Color.menu.text
+                                                opacity: 0.45
+                                                font.family: Style.font.menuFamily
+                                                font.pixelSize: Style.font.caption
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Item {
+                                id: footerHideConfirmationLayer
+                                anchors.fill: parent
+                                visible: root.footerHideConfirmationOpen
+                                z: 10
+                                onVisibleChanged: {
+                                    if (visible && overviewWindow.acceptsKeyboard)
+                                        Qt.callLater(function () {
+                                            if (footerHideConfirmationLayer.visible)
+                                                footerHideAcknowledgement.forceActiveFocus();
+                                        });
+                                    else if (!visible && root.settingsOpen && overviewWindow.acceptsKeyboard)
+                                        Qt.callLater(function () {
+                                            if (settingsLayer.visible && !footerHideConfirmationLayer.visible)
+                                                bottomTextToggle.forceActiveFocus();
+                                        });
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: root.closeFooterHideConfirmation()
+                                }
+
+                                Rectangle {
+                                    anchors.fill: parent
+                                    color: "black"
+                                    opacity: 0.72
+                                }
+
+                                Rectangle {
+                                    id: footerHideDialog
+                                    anchors.centerIn: parent
+                                    width: Math.min(Style.space(560), parent.width - Style.space(80))
+                                    height: Math.min(parent.height - Style.space(80), footerHideContent.implicitHeight + Style.space(56))
+                                    radius: Style.cornerRadius
+                                    color: Color.menu.background
+                                    border.color: Color.menu.border
+                                    border.width: Math.max(1, Style.normalBorderWidth)
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        onClicked: function (mouse) { mouse.accepted = true; }
+                                    }
+
+                                    ColumnLayout {
+                                        id: footerHideContent
+                                        anchors.fill: parent
+                                        anchors.margins: Style.space(28)
+                                        spacing: Style.spacing.lg
+
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: "Hide bottom text?"
+                                            textFormat: Text.PlainText
+                                            color: Color.menu.text
+                                            font.family: Style.font.menuFamily
+                                            font.pixelSize: Style.font.heading
+                                            font.bold: true
+                                        }
+
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: "This also hides the Settings link. You can turn it back on while this panel remains open."
                                             textFormat: Text.PlainText
                                             wrapMode: Text.WordWrap
                                             color: Color.menu.text
                                             font.family: Style.font.menuFamily
-                                            font.pixelSize: Style.font.bodySmall
+                                            font.pixelSize: Style.font.body
                                         }
-                                    }
 
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        cursorShape: Qt.PointingHandCursor
-                                        onPressed: footerHideAcknowledgement.forceActiveFocus()
-                                        onClicked: root.footerHideAcknowledged = !root.footerHideAcknowledged
-                                    }
-                                }
+                                        Rectangle {
+                                            Layout.fillWidth: true
+                                            Layout.preferredHeight: recoveryText.implicitHeight + Style.space(24)
+                                            color: Color.background
+                                            border.color: Color.menu.border
+                                            border.width: Math.max(1, Style.normalBorderWidth)
 
-                                RowLayout {
-                                    Layout.fillWidth: true
-                                    Layout.topMargin: Style.spacing.sm
-                                    spacing: Style.spacing.md
+                                            Text {
+                                                id: recoveryText
+                                                anchors.fill: parent
+                                                anchors.margins: Style.space(12)
+                                                text: "After closing Settings, restore it in ~/.config/omarchy/shell.json by setting showFooter to true in the expose.window-overview plugin entry."
+                                                textFormat: Text.PlainText
+                                                wrapMode: Text.WordWrap
+                                                color: Color.menu.text
+                                                opacity: 0.72
+                                                font.family: Style.font.menuFamily
+                                                font.pixelSize: Style.font.caption
+                                            }
+                                        }
 
-                                    Item { Layout.fillWidth: true }
+                                        Item {
+                                            id: footerHideAcknowledgement
+                                            Layout.fillWidth: true
+                                            Layout.preferredHeight: Math.max(Style.space(40), acknowledgementText.implicitHeight)
+                                            activeFocusOnTab: true
 
-                                    DialogButton {
-                                        id: footerHideCancelButton
-                                        label: "Cancel"
-                                        onClicked: root.closeFooterHideConfirmation()
-                                    }
+                                            Keys.onPressed: function (event) {
+                                                if (root.handleSettingsNavigation(event))
+                                                    return;
+                                                if (event.key !== Qt.Key_Space && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter) {
+                                                    event.accepted = false;
+                                                    return;
+                                                }
+                                                root.footerHideAcknowledged = !root.footerHideAcknowledged;
+                                                event.accepted = true;
+                                            }
 
-                                    DialogButton {
-                                        id: footerHideConfirmButton
-                                        label: "Hide bottom text"
-                                        destructive: true
-                                        enabled: root.footerHideAcknowledged
-                                        onClicked: root.confirmFooterHide()
+                                            RowLayout {
+                                                id: acknowledgementRow
+                                                anchors.fill: parent
+                                                spacing: Style.spacing.md
+
+                                                Rectangle {
+                                                    Layout.preferredWidth: Style.space(18)
+                                                    Layout.preferredHeight: Style.space(18)
+                                                    color: root.footerHideAcknowledged ? Color.accent : "transparent"
+                                                    border.color: footerHideAcknowledgement.activeFocus || root.footerHideAcknowledged
+                                                        ? Color.accent
+                                                        : Color.menu.border
+                                                    border.width: footerHideAcknowledgement.activeFocus
+                                                        ? Math.max(2, Style.focusBorderWidth)
+                                                        : Math.max(1, Style.normalBorderWidth)
+
+                                                    Text {
+                                                        anchors.centerIn: parent
+                                                        visible: root.footerHideAcknowledged
+                                                        text: "✓"
+                                                        textFormat: Text.PlainText
+                                                        color: Color.background
+                                                        font.family: Style.font.menuFamily
+                                                        font.pixelSize: Style.font.caption
+                                                        font.bold: true
+                                                    }
+                                                }
+
+                                                Text {
+                                                    id: acknowledgementText
+                                                    Layout.fillWidth: true
+                                                    text: "I understand that closing Settings while it is hidden requires editing the config."
+                                                    textFormat: Text.PlainText
+                                                    wrapMode: Text.WordWrap
+                                                    color: Color.menu.text
+                                                    font.family: Style.font.menuFamily
+                                                    font.pixelSize: Style.font.bodySmall
+                                                }
+                                            }
+
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                cursorShape: Qt.PointingHandCursor
+                                                onPressed: footerHideAcknowledgement.forceActiveFocus()
+                                                onClicked: root.footerHideAcknowledged = !root.footerHideAcknowledged
+                                            }
+                                        }
+
+                                        RowLayout {
+                                            Layout.fillWidth: true
+                                            Layout.topMargin: Style.spacing.sm
+                                            spacing: Style.spacing.md
+
+                                            Item { Layout.fillWidth: true }
+
+                                            DialogButton {
+                                                id: footerHideCancelButton
+                                                label: "Cancel"
+                                                onClicked: root.closeFooterHideConfirmation()
+                                            }
+
+                                            DialogButton {
+                                                id: footerHideConfirmButton
+                                                label: "Hide bottom text"
+                                                destructive: true
+                                                enabled: root.footerHideAcknowledged
+                                                onClicked: root.confirmFooterHide()
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ omarchy plugin add https://github.com/kristofferR/omarchy-expose.git --enable
 That's it: the top-left hot corner works right away. Optionally, bind a key in `~/.config/hypr/bindings.lua`, then run `hyprctl reload`:
 
 ```lua
-o.bind("SUPER + A", "Exposé", "omarchy-shell expose toggle")
+o.bind("SUPER + A", "Exposé", hl.dsp.event("expose.window-overview:toggle"))
 ```
 
 Any unused chord works. Avoid modifier-only bindings such as standalone Super; Hyprland cannot reliably distinguish them from the start of normal Super shortcuts.
@@ -138,7 +138,7 @@ Exposé runs unsandboxed inside Omarchy Shell with your user's permissions.
 - **No thumbnails:** verify Hyprland exposes toplevel-export support and no screen-capture policy blocks Quickshell. Cards stay usable with fallback labels.
 - **Workspace says “—”:** Exposé matches foreign-toplevel objects to `hyprctl clients -j`; very short-lived windows or identical title/class pairs can briefly be ambiguous.
 - **Plugin not listed:** run `omarchy plugin validate .`, then `omarchy-shell shell rescanPlugins`.
-- **Shortcut does nothing:** run `hyprctl reload`, check `hyprctl configerrors`, and test `omarchy-shell expose toggle` directly.
+- **Shortcut does nothing:** run `hyprctl reload`, check `hyprctl configerrors`, and test `hyprctl dispatch 'hl.dsp.event("expose.window-overview:toggle")'` directly.
 
 ## Credits
 

--- a/background-blur-session
+++ b/background-blur-session
@@ -8,23 +8,24 @@ run_hyprctl() {
   timeout --signal=TERM --kill-after=1 2 hyprctl "$@"
 }
 
-read_option() {
-  local option="$1"
-  local field="$2"
-  run_hyprctl -j getoption "$option" |
-    jq -er --arg field "$field" '
-      if has($field) and .[$field] != null
-      then .[$field] | tostring
-      else error("missing " + $field)
-      end'
-}
-
-saved_enabled=$(run_hyprctl -j getoption "decoration:blur:enabled" | jq -er '
-  if has("bool") then .bool
-  elif has("int") then .int != 0
-  else error("missing bool or int value")
-  end | tostring')
-saved_size=$(read_option "decoration:blur:size" "int")
+IFS=$'\t' read -r saved_enabled saved_size < <(
+  run_hyprctl --batch -j 'getoption decoration:blur:enabled; getoption decoration:blur:size' |
+    jq -ser '
+      if length != 2 then error("expected two blur options") else . end
+      | [
+          (.[0]
+            | if has("bool") then .bool
+              elif has("int") then .int != 0
+              else error("missing bool or int value")
+              end
+            | tostring),
+          (.[1]
+            | if has("int") and .int != null then .int | tostring
+              else error("missing int value")
+              end)
+        ]
+      | @tsv'
+)
 restored=false
 
 apply_saved_blur() {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "expose.window-overview",
   "name": "Exposé",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "author": "Kristoffer Risanger (@kristofferR)",
   "license": "MIT",
   "description": "macOS-style Exposé for Omarchy: one key or a hot corner shows every open window as a live preview. Type to search, press Space to Quick Look, press Enter to launch.",


### PR DESCRIPTION
Opening Exposé still did avoidable work before the opening animation and eagerly kept the full settings UI alive.

This overlaps client and blur initialization, batches blur-state reads, lazy-loads settings, and adds a resident Hyprland event path for keybindings. It also bumps the release to 3.0.0.

Validation:
- qmllint Overview.qml
- shell and Lua syntax checks
- omarchy plugin validate .
- live open, settings, close, and blur restoration checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the release version to 3.0.0.

- **Bug Fixes**
  - Improved background blur settings detection for more efficient and reliable session handling.
  - Updated documentation examples and troubleshooting instructions to use direct overview toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->